### PR TITLE
DEVOPS-5820 adding Must() & Refresh() methods for all client via codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,10 +400,9 @@ or simply
 
 ```go 
 
-  // build & return an ECS client for the `r2` provider with 
-  // additioanl functional options, these are passed directly
-  // to the underlying server.NewFromConfig(...) function for 
-  // additional configuration
+  // build & return an ECS client for the `r2` provider 
+  // Since Must() is used, an error while creating the Client
+  // will result in a panic
   client := _ecs.Must(r2)
 
 

--- a/README.md
+++ b/README.md
@@ -364,13 +364,18 @@ import (
 
 )
 ```
-All client packages expose `2` helper functions: `Client()` & `Delete()`. 
+All client packages expose `4` helper functions: `Client()`, `Must()`, `Delete()` and `Refresh()`
 
 The `Client` function returns a singleton AWS service client. It uses the supplied `providers.CredsProvdier` 
 sub-type as the configuration (`aws.Config`).
 
+The `Must()` function is a wrapper for the `Client()` function & panics if a non-nil error is returned. It 
+allows convenience for initializing or passing AWS clients in the client code.
+
 The `Delete` function clears the singleton instance for the supplied `provider` to force the module to create 
 and return a new instance in the next call to `Client`
+
+The `Refresh()` function discards the singleton client if it exists & recreates it.
 
 The `aws-ccp-go` supports basic configurartion out of the box. If more specific configuration is required, 
 functional options can be supplied to client builder methods for instance: AWS Region or Client Retry Attempts etc.  
@@ -387,6 +392,19 @@ forwarded as-is to the clients' `NewFromConfig(...)` builder functions.
 			o.Region = "us-east-2" 
 			o.RetryMaxAttempts = 4
 	})
+
+
+```
+
+or simply 
+
+```go 
+
+  // build & return an ECS client for the `r2` provider with 
+  // additioanl functional options, these are passed directly
+  // to the underlying server.NewFromConfig(...) function for 
+  // additional configuration
+  client := _ecs.Must(r2)
 
 
 ```

--- a/clients/_accessanalyzer/client.go
+++ b/clients/_accessanalyzer/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _accessanalyzer provides AWS client management functions for the accessanalyzer
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*accessanalyzer.Opt
 	return client.(*accessanalyzer.Client), nil
 }
 
+// Must wraps the _accessanalyzer.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*accessanalyzer.Options)) *accessanalyzer.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached accessanalyzer client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached accessanalyzer client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*accessanalyzer.Options)) (*accessanalyzer.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_account/client.go
+++ b/clients/_account/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _account provides AWS client management functions for the account
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*account.Options)) 
 	return client.(*account.Client), nil
 }
 
+// Must wraps the _account.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*account.Options)) *account.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached account client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached account client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*account.Options)) (*account.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_acm/client.go
+++ b/clients/_acm/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _acm provides AWS client management functions for the acm
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*acm.Options)) (*ac
 	return client.(*acm.Client), nil
 }
 
+// Must wraps the _acm.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*acm.Options)) *acm.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached acm client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached acm client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*acm.Options)) (*acm.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_acmpca/client.go
+++ b/clients/_acmpca/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _acmpca provides AWS client management functions for the acmpca
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*acmpca.Options)) (
 	return client.(*acmpca.Client), nil
 }
 
+// Must wraps the _acmpca.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*acmpca.Options)) *acmpca.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached acmpca client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached acmpca client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*acmpca.Options)) (*acmpca.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_alexaforbusiness/client.go
+++ b/clients/_alexaforbusiness/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _alexaforbusiness provides AWS client management functions for the alexaforbusiness
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*alexaforbusiness.O
 	return client.(*alexaforbusiness.Client), nil
 }
 
+// Must wraps the _alexaforbusiness.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*alexaforbusiness.Options)) *alexaforbusiness.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached alexaforbusiness client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached alexaforbusiness client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*alexaforbusiness.Options)) (*alexaforbusiness.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_amp/client.go
+++ b/clients/_amp/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _amp provides AWS client management functions for the amp
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*amp.Options)) (*am
 	return client.(*amp.Client), nil
 }
 
+// Must wraps the _amp.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*amp.Options)) *amp.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached amp client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached amp client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*amp.Options)) (*amp.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_amplify/client.go
+++ b/clients/_amplify/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _amplify provides AWS client management functions for the amplify
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*amplify.Options)) 
 	return client.(*amplify.Client), nil
 }
 
+// Must wraps the _amplify.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*amplify.Options)) *amplify.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached amplify client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached amplify client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*amplify.Options)) (*amplify.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_amplifybackend/client.go
+++ b/clients/_amplifybackend/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _amplifybackend provides AWS client management functions for the amplifybackend
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*amplifybackend.Opt
 	return client.(*amplifybackend.Client), nil
 }
 
+// Must wraps the _amplifybackend.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*amplifybackend.Options)) *amplifybackend.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached amplifybackend client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached amplifybackend client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*amplifybackend.Options)) (*amplifybackend.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_amplifyuibuilder/client.go
+++ b/clients/_amplifyuibuilder/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _amplifyuibuilder provides AWS client management functions for the amplifyuibuilder
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*amplifyuibuilder.O
 	return client.(*amplifyuibuilder.Client), nil
 }
 
+// Must wraps the _amplifyuibuilder.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*amplifyuibuilder.Options)) *amplifyuibuilder.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached amplifyuibuilder client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached amplifyuibuilder client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*amplifyuibuilder.Options)) (*amplifyuibuilder.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_apigateway/client.go
+++ b/clients/_apigateway/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _apigateway provides AWS client management functions for the apigateway
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*apigateway.Options
 	return client.(*apigateway.Client), nil
 }
 
+// Must wraps the _apigateway.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*apigateway.Options)) *apigateway.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached apigateway client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached apigateway client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*apigateway.Options)) (*apigateway.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_apigatewaymanagementapi/client.go
+++ b/clients/_apigatewaymanagementapi/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _apigatewaymanagementapi provides AWS client management functions for the apigatewaymanagementapi
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*apigatewaymanageme
 	return client.(*apigatewaymanagementapi.Client), nil
 }
 
+// Must wraps the _apigatewaymanagementapi.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*apigatewaymanagementapi.Options)) *apigatewaymanagementapi.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached apigatewaymanagementapi client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached apigatewaymanagementapi client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*apigatewaymanagementapi.Options)) (*apigatewaymanagementapi.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_apigatewayv2/client.go
+++ b/clients/_apigatewayv2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _apigatewayv2 provides AWS client management functions for the apigatewayv2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*apigatewayv2.Optio
 	return client.(*apigatewayv2.Client), nil
 }
 
+// Must wraps the _apigatewayv2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*apigatewayv2.Options)) *apigatewayv2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached apigatewayv2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached apigatewayv2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*apigatewayv2.Options)) (*apigatewayv2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_appconfig/client.go
+++ b/clients/_appconfig/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _appconfig provides AWS client management functions for the appconfig
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*appconfig.Options)
 	return client.(*appconfig.Client), nil
 }
 
+// Must wraps the _appconfig.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*appconfig.Options)) *appconfig.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached appconfig client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached appconfig client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*appconfig.Options)) (*appconfig.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_appconfigdata/client.go
+++ b/clients/_appconfigdata/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _appconfigdata provides AWS client management functions for the appconfigdata
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*appconfigdata.Opti
 	return client.(*appconfigdata.Client), nil
 }
 
+// Must wraps the _appconfigdata.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*appconfigdata.Options)) *appconfigdata.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached appconfigdata client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached appconfigdata client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*appconfigdata.Options)) (*appconfigdata.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_appfabric/client.go
+++ b/clients/_appfabric/client.go
@@ -1,0 +1,71 @@
+// AUTO-GENERATED CODE - DO NOT EDIT
+// See instructions under /codegen/README.md
+// GENERATED ON 2023-07-31 09:25:17
+
+// Package _appfabric provides AWS client management functions for the appfabric
+// AWS service.
+//
+// The Client() is a wrapper on appfabric.NewFromConfig(), which creates & caches
+// the client.
+//
+// The Delete() clears the cached client.
+//
+package _appfabric
+
+import (
+	"sync"
+
+	"github.com/TouchBistro/aws-ccp-go/providers"
+	"github.com/aws/aws-sdk-go-v2/service/appfabric"
+)
+
+var cmap sync.Map
+
+// Client builds or returns the singleton appfabric client for the supplied provider
+// If functional options are supplied, they are passed as-is to the underlying NewFromConfig(...)
+// for the corresponding client
+func Client(provider providers.CredsProvider, optFns ...func(*appfabric.Options)) (*appfabric.Client, error) {
+
+	if provider == nil {
+		return nil, providers.ErrNilProvider
+	}
+	if _, ok := cmap.Load(provider.Key()); !ok {
+		client := appfabric.NewFromConfig(provider.Config(), optFns...)
+		cmap.Store(provider.Key(), client)
+	}
+	client, _ := cmap.Load(provider.Key())
+	return client.(*appfabric.Client), nil
+}
+
+// Must wraps the _appfabric.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*appfabric.Options)) *appfabric.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// Delete removes the cached appfabric client for the supplied provider; This foreces the subsequent
+// calls to Client() for the same provider to recreate & return a new instnce.
+func Delete(provider providers.CredsProvider) error {
+
+	if provider == nil {
+		return providers.ErrNilProvider
+	}
+	if _, ok := cmap.Load(provider.Key()); ok {
+		cmap.Delete(provider.Key())
+	}
+	return nil
+}
+
+// Refresh discards the cached appfabric client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*appfabric.Options)) (*appfabric.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
+}

--- a/clients/_appflow/client.go
+++ b/clients/_appflow/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _appflow provides AWS client management functions for the appflow
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*appflow.Options)) 
 	return client.(*appflow.Client), nil
 }
 
+// Must wraps the _appflow.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*appflow.Options)) *appflow.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached appflow client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached appflow client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*appflow.Options)) (*appflow.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_appintegrations/client.go
+++ b/clients/_appintegrations/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _appintegrations provides AWS client management functions for the appintegrations
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*appintegrations.Op
 	return client.(*appintegrations.Client), nil
 }
 
+// Must wraps the _appintegrations.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*appintegrations.Options)) *appintegrations.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached appintegrations client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached appintegrations client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*appintegrations.Options)) (*appintegrations.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_applicationautoscaling/client.go
+++ b/clients/_applicationautoscaling/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _applicationautoscaling provides AWS client management functions for the applicationautoscaling
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*applicationautosca
 	return client.(*applicationautoscaling.Client), nil
 }
 
+// Must wraps the _applicationautoscaling.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*applicationautoscaling.Options)) *applicationautoscaling.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached applicationautoscaling client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached applicationautoscaling client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*applicationautoscaling.Options)) (*applicationautoscaling.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_applicationcostprofiler/client.go
+++ b/clients/_applicationcostprofiler/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _applicationcostprofiler provides AWS client management functions for the applicationcostprofiler
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*applicationcostpro
 	return client.(*applicationcostprofiler.Client), nil
 }
 
+// Must wraps the _applicationcostprofiler.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*applicationcostprofiler.Options)) *applicationcostprofiler.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached applicationcostprofiler client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached applicationcostprofiler client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*applicationcostprofiler.Options)) (*applicationcostprofiler.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_applicationdiscoveryservice/client.go
+++ b/clients/_applicationdiscoveryservice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _applicationdiscoveryservice provides AWS client management functions for the applicationdiscoveryservice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*applicationdiscove
 	return client.(*applicationdiscoveryservice.Client), nil
 }
 
+// Must wraps the _applicationdiscoveryservice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*applicationdiscoveryservice.Options)) *applicationdiscoveryservice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached applicationdiscoveryservice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached applicationdiscoveryservice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*applicationdiscoveryservice.Options)) (*applicationdiscoveryservice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_applicationinsights/client.go
+++ b/clients/_applicationinsights/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _applicationinsights provides AWS client management functions for the applicationinsights
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*applicationinsight
 	return client.(*applicationinsights.Client), nil
 }
 
+// Must wraps the _applicationinsights.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*applicationinsights.Options)) *applicationinsights.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached applicationinsights client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached applicationinsights client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*applicationinsights.Options)) (*applicationinsights.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_appmesh/client.go
+++ b/clients/_appmesh/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _appmesh provides AWS client management functions for the appmesh
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*appmesh.Options)) 
 	return client.(*appmesh.Client), nil
 }
 
+// Must wraps the _appmesh.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*appmesh.Options)) *appmesh.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached appmesh client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached appmesh client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*appmesh.Options)) (*appmesh.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_apprunner/client.go
+++ b/clients/_apprunner/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _apprunner provides AWS client management functions for the apprunner
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*apprunner.Options)
 	return client.(*apprunner.Client), nil
 }
 
+// Must wraps the _apprunner.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*apprunner.Options)) *apprunner.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached apprunner client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached apprunner client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*apprunner.Options)) (*apprunner.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_appstream/client.go
+++ b/clients/_appstream/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _appstream provides AWS client management functions for the appstream
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*appstream.Options)
 	return client.(*appstream.Client), nil
 }
 
+// Must wraps the _appstream.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*appstream.Options)) *appstream.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached appstream client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached appstream client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*appstream.Options)) (*appstream.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_appsync/client.go
+++ b/clients/_appsync/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _appsync provides AWS client management functions for the appsync
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*appsync.Options)) 
 	return client.(*appsync.Client), nil
 }
 
+// Must wraps the _appsync.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*appsync.Options)) *appsync.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached appsync client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached appsync client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*appsync.Options)) (*appsync.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_arczonalshift/client.go
+++ b/clients/_arczonalshift/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _arczonalshift provides AWS client management functions for the arczonalshift
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*arczonalshift.Opti
 	return client.(*arczonalshift.Client), nil
 }
 
+// Must wraps the _arczonalshift.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*arczonalshift.Options)) *arczonalshift.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached arczonalshift client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached arczonalshift client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*arczonalshift.Options)) (*arczonalshift.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_athena/client.go
+++ b/clients/_athena/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _athena provides AWS client management functions for the athena
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*athena.Options)) (
 	return client.(*athena.Client), nil
 }
 
+// Must wraps the _athena.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*athena.Options)) *athena.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached athena client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached athena client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*athena.Options)) (*athena.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_auditmanager/client.go
+++ b/clients/_auditmanager/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _auditmanager provides AWS client management functions for the auditmanager
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*auditmanager.Optio
 	return client.(*auditmanager.Client), nil
 }
 
+// Must wraps the _auditmanager.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*auditmanager.Options)) *auditmanager.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached auditmanager client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached auditmanager client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*auditmanager.Options)) (*auditmanager.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_autoscaling/client.go
+++ b/clients/_autoscaling/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _autoscaling provides AWS client management functions for the autoscaling
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*autoscaling.Option
 	return client.(*autoscaling.Client), nil
 }
 
+// Must wraps the _autoscaling.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*autoscaling.Options)) *autoscaling.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached autoscaling client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached autoscaling client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*autoscaling.Options)) (*autoscaling.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_autoscalingplans/client.go
+++ b/clients/_autoscalingplans/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _autoscalingplans provides AWS client management functions for the autoscalingplans
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*autoscalingplans.O
 	return client.(*autoscalingplans.Client), nil
 }
 
+// Must wraps the _autoscalingplans.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*autoscalingplans.Options)) *autoscalingplans.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached autoscalingplans client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached autoscalingplans client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*autoscalingplans.Options)) (*autoscalingplans.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_backup/client.go
+++ b/clients/_backup/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _backup provides AWS client management functions for the backup
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*backup.Options)) (
 	return client.(*backup.Client), nil
 }
 
+// Must wraps the _backup.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*backup.Options)) *backup.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached backup client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached backup client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*backup.Options)) (*backup.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_backupgateway/client.go
+++ b/clients/_backupgateway/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _backupgateway provides AWS client management functions for the backupgateway
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*backupgateway.Opti
 	return client.(*backupgateway.Client), nil
 }
 
+// Must wraps the _backupgateway.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*backupgateway.Options)) *backupgateway.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached backupgateway client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached backupgateway client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*backupgateway.Options)) (*backupgateway.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_backupstorage/client.go
+++ b/clients/_backupstorage/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _backupstorage provides AWS client management functions for the backupstorage
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*backupstorage.Opti
 	return client.(*backupstorage.Client), nil
 }
 
+// Must wraps the _backupstorage.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*backupstorage.Options)) *backupstorage.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached backupstorage client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached backupstorage client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*backupstorage.Options)) (*backupstorage.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_batch/client.go
+++ b/clients/_batch/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _batch provides AWS client management functions for the batch
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*batch.Options)) (*
 	return client.(*batch.Client), nil
 }
 
+// Must wraps the _batch.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*batch.Options)) *batch.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached batch client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached batch client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*batch.Options)) (*batch.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_billingconductor/client.go
+++ b/clients/_billingconductor/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _billingconductor provides AWS client management functions for the billingconductor
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*billingconductor.O
 	return client.(*billingconductor.Client), nil
 }
 
+// Must wraps the _billingconductor.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*billingconductor.Options)) *billingconductor.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached billingconductor client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached billingconductor client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*billingconductor.Options)) (*billingconductor.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_braket/client.go
+++ b/clients/_braket/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _braket provides AWS client management functions for the braket
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*braket.Options)) (
 	return client.(*braket.Client), nil
 }
 
+// Must wraps the _braket.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*braket.Options)) *braket.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached braket client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached braket client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*braket.Options)) (*braket.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_budgets/client.go
+++ b/clients/_budgets/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _budgets provides AWS client management functions for the budgets
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*budgets.Options)) 
 	return client.(*budgets.Client), nil
 }
 
+// Must wraps the _budgets.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*budgets.Options)) *budgets.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached budgets client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached budgets client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*budgets.Options)) (*budgets.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_chime/client.go
+++ b/clients/_chime/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _chime provides AWS client management functions for the chime
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*chime.Options)) (*
 	return client.(*chime.Client), nil
 }
 
+// Must wraps the _chime.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*chime.Options)) *chime.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached chime client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached chime client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*chime.Options)) (*chime.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_chimesdkidentity/client.go
+++ b/clients/_chimesdkidentity/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _chimesdkidentity provides AWS client management functions for the chimesdkidentity
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*chimesdkidentity.O
 	return client.(*chimesdkidentity.Client), nil
 }
 
+// Must wraps the _chimesdkidentity.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*chimesdkidentity.Options)) *chimesdkidentity.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached chimesdkidentity client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached chimesdkidentity client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*chimesdkidentity.Options)) (*chimesdkidentity.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_chimesdkmediapipelines/client.go
+++ b/clients/_chimesdkmediapipelines/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _chimesdkmediapipelines provides AWS client management functions for the chimesdkmediapipelines
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*chimesdkmediapipel
 	return client.(*chimesdkmediapipelines.Client), nil
 }
 
+// Must wraps the _chimesdkmediapipelines.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*chimesdkmediapipelines.Options)) *chimesdkmediapipelines.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached chimesdkmediapipelines client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached chimesdkmediapipelines client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*chimesdkmediapipelines.Options)) (*chimesdkmediapipelines.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_chimesdkmeetings/client.go
+++ b/clients/_chimesdkmeetings/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _chimesdkmeetings provides AWS client management functions for the chimesdkmeetings
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*chimesdkmeetings.O
 	return client.(*chimesdkmeetings.Client), nil
 }
 
+// Must wraps the _chimesdkmeetings.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*chimesdkmeetings.Options)) *chimesdkmeetings.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached chimesdkmeetings client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached chimesdkmeetings client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*chimesdkmeetings.Options)) (*chimesdkmeetings.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_chimesdkmessaging/client.go
+++ b/clients/_chimesdkmessaging/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _chimesdkmessaging provides AWS client management functions for the chimesdkmessaging
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*chimesdkmessaging.
 	return client.(*chimesdkmessaging.Client), nil
 }
 
+// Must wraps the _chimesdkmessaging.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*chimesdkmessaging.Options)) *chimesdkmessaging.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached chimesdkmessaging client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached chimesdkmessaging client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*chimesdkmessaging.Options)) (*chimesdkmessaging.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_chimesdkvoice/client.go
+++ b/clients/_chimesdkvoice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _chimesdkvoice provides AWS client management functions for the chimesdkvoice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*chimesdkvoice.Opti
 	return client.(*chimesdkvoice.Client), nil
 }
 
+// Must wraps the _chimesdkvoice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*chimesdkvoice.Options)) *chimesdkvoice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached chimesdkvoice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached chimesdkvoice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*chimesdkvoice.Options)) (*chimesdkvoice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cleanrooms/client.go
+++ b/clients/_cleanrooms/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cleanrooms provides AWS client management functions for the cleanrooms
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cleanrooms.Options
 	return client.(*cleanrooms.Client), nil
 }
 
+// Must wraps the _cleanrooms.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cleanrooms.Options)) *cleanrooms.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cleanrooms client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cleanrooms client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cleanrooms.Options)) (*cleanrooms.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloud9/client.go
+++ b/clients/_cloud9/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloud9 provides AWS client management functions for the cloud9
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloud9.Options)) (
 	return client.(*cloud9.Client), nil
 }
 
+// Must wraps the _cloud9.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloud9.Options)) *cloud9.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloud9 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloud9 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloud9.Options)) (*cloud9.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloudcontrol/client.go
+++ b/clients/_cloudcontrol/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloudcontrol provides AWS client management functions for the cloudcontrol
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloudcontrol.Optio
 	return client.(*cloudcontrol.Client), nil
 }
 
+// Must wraps the _cloudcontrol.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloudcontrol.Options)) *cloudcontrol.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloudcontrol client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloudcontrol client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloudcontrol.Options)) (*cloudcontrol.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_clouddirectory/client.go
+++ b/clients/_clouddirectory/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _clouddirectory provides AWS client management functions for the clouddirectory
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*clouddirectory.Opt
 	return client.(*clouddirectory.Client), nil
 }
 
+// Must wraps the _clouddirectory.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*clouddirectory.Options)) *clouddirectory.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached clouddirectory client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached clouddirectory client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*clouddirectory.Options)) (*clouddirectory.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloudformation/client.go
+++ b/clients/_cloudformation/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloudformation provides AWS client management functions for the cloudformation
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloudformation.Opt
 	return client.(*cloudformation.Client), nil
 }
 
+// Must wraps the _cloudformation.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloudformation.Options)) *cloudformation.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloudformation client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloudformation client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloudformation.Options)) (*cloudformation.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloudfront/client.go
+++ b/clients/_cloudfront/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloudfront provides AWS client management functions for the cloudfront
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloudfront.Options
 	return client.(*cloudfront.Client), nil
 }
 
+// Must wraps the _cloudfront.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloudfront.Options)) *cloudfront.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloudfront client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloudfront client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloudfront.Options)) (*cloudfront.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloudhsm/client.go
+++ b/clients/_cloudhsm/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloudhsm provides AWS client management functions for the cloudhsm
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloudhsm.Options))
 	return client.(*cloudhsm.Client), nil
 }
 
+// Must wraps the _cloudhsm.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloudhsm.Options)) *cloudhsm.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloudhsm client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloudhsm client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloudhsm.Options)) (*cloudhsm.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloudhsmv2/client.go
+++ b/clients/_cloudhsmv2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloudhsmv2 provides AWS client management functions for the cloudhsmv2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloudhsmv2.Options
 	return client.(*cloudhsmv2.Client), nil
 }
 
+// Must wraps the _cloudhsmv2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloudhsmv2.Options)) *cloudhsmv2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloudhsmv2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloudhsmv2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloudhsmv2.Options)) (*cloudhsmv2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloudsearch/client.go
+++ b/clients/_cloudsearch/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloudsearch provides AWS client management functions for the cloudsearch
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloudsearch.Option
 	return client.(*cloudsearch.Client), nil
 }
 
+// Must wraps the _cloudsearch.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloudsearch.Options)) *cloudsearch.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloudsearch client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloudsearch client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloudsearch.Options)) (*cloudsearch.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloudsearchdomain/client.go
+++ b/clients/_cloudsearchdomain/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloudsearchdomain provides AWS client management functions for the cloudsearchdomain
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloudsearchdomain.
 	return client.(*cloudsearchdomain.Client), nil
 }
 
+// Must wraps the _cloudsearchdomain.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloudsearchdomain.Options)) *cloudsearchdomain.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloudsearchdomain client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloudsearchdomain client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloudsearchdomain.Options)) (*cloudsearchdomain.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloudtrail/client.go
+++ b/clients/_cloudtrail/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloudtrail provides AWS client management functions for the cloudtrail
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloudtrail.Options
 	return client.(*cloudtrail.Client), nil
 }
 
+// Must wraps the _cloudtrail.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloudtrail.Options)) *cloudtrail.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloudtrail client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloudtrail client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloudtrail.Options)) (*cloudtrail.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloudtraildata/client.go
+++ b/clients/_cloudtraildata/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloudtraildata provides AWS client management functions for the cloudtraildata
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloudtraildata.Opt
 	return client.(*cloudtraildata.Client), nil
 }
 
+// Must wraps the _cloudtraildata.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloudtraildata.Options)) *cloudtraildata.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloudtraildata client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloudtraildata client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloudtraildata.Options)) (*cloudtraildata.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloudwatch/client.go
+++ b/clients/_cloudwatch/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloudwatch provides AWS client management functions for the cloudwatch
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloudwatch.Options
 	return client.(*cloudwatch.Client), nil
 }
 
+// Must wraps the _cloudwatch.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloudwatch.Options)) *cloudwatch.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloudwatch client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloudwatch client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloudwatch.Options)) (*cloudwatch.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloudwatchevents/client.go
+++ b/clients/_cloudwatchevents/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloudwatchevents provides AWS client management functions for the cloudwatchevents
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloudwatchevents.O
 	return client.(*cloudwatchevents.Client), nil
 }
 
+// Must wraps the _cloudwatchevents.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloudwatchevents.Options)) *cloudwatchevents.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloudwatchevents client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloudwatchevents client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloudwatchevents.Options)) (*cloudwatchevents.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cloudwatchlogs/client.go
+++ b/clients/_cloudwatchlogs/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cloudwatchlogs provides AWS client management functions for the cloudwatchlogs
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cloudwatchlogs.Opt
 	return client.(*cloudwatchlogs.Client), nil
 }
 
+// Must wraps the _cloudwatchlogs.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cloudwatchlogs.Options)) *cloudwatchlogs.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cloudwatchlogs client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cloudwatchlogs client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_codeartifact/client.go
+++ b/clients/_codeartifact/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _codeartifact provides AWS client management functions for the codeartifact
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*codeartifact.Optio
 	return client.(*codeartifact.Client), nil
 }
 
+// Must wraps the _codeartifact.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*codeartifact.Options)) *codeartifact.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached codeartifact client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached codeartifact client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*codeartifact.Options)) (*codeartifact.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_codebuild/client.go
+++ b/clients/_codebuild/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _codebuild provides AWS client management functions for the codebuild
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*codebuild.Options)
 	return client.(*codebuild.Client), nil
 }
 
+// Must wraps the _codebuild.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*codebuild.Options)) *codebuild.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached codebuild client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached codebuild client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*codebuild.Options)) (*codebuild.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_codecatalyst/client.go
+++ b/clients/_codecatalyst/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _codecatalyst provides AWS client management functions for the codecatalyst
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*codecatalyst.Optio
 	return client.(*codecatalyst.Client), nil
 }
 
+// Must wraps the _codecatalyst.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*codecatalyst.Options)) *codecatalyst.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached codecatalyst client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached codecatalyst client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*codecatalyst.Options)) (*codecatalyst.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_codecommit/client.go
+++ b/clients/_codecommit/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _codecommit provides AWS client management functions for the codecommit
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*codecommit.Options
 	return client.(*codecommit.Client), nil
 }
 
+// Must wraps the _codecommit.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*codecommit.Options)) *codecommit.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached codecommit client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached codecommit client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*codecommit.Options)) (*codecommit.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_codedeploy/client.go
+++ b/clients/_codedeploy/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _codedeploy provides AWS client management functions for the codedeploy
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*codedeploy.Options
 	return client.(*codedeploy.Client), nil
 }
 
+// Must wraps the _codedeploy.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*codedeploy.Options)) *codedeploy.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached codedeploy client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached codedeploy client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*codedeploy.Options)) (*codedeploy.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_codeguruprofiler/client.go
+++ b/clients/_codeguruprofiler/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _codeguruprofiler provides AWS client management functions for the codeguruprofiler
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*codeguruprofiler.O
 	return client.(*codeguruprofiler.Client), nil
 }
 
+// Must wraps the _codeguruprofiler.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*codeguruprofiler.Options)) *codeguruprofiler.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached codeguruprofiler client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached codeguruprofiler client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*codeguruprofiler.Options)) (*codeguruprofiler.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_codegurureviewer/client.go
+++ b/clients/_codegurureviewer/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _codegurureviewer provides AWS client management functions for the codegurureviewer
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*codegurureviewer.O
 	return client.(*codegurureviewer.Client), nil
 }
 
+// Must wraps the _codegurureviewer.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*codegurureviewer.Options)) *codegurureviewer.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached codegurureviewer client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached codegurureviewer client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*codegurureviewer.Options)) (*codegurureviewer.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_codegurusecurity/client.go
+++ b/clients/_codegurusecurity/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _codegurusecurity provides AWS client management functions for the codegurusecurity
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*codegurusecurity.O
 	return client.(*codegurusecurity.Client), nil
 }
 
+// Must wraps the _codegurusecurity.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*codegurusecurity.Options)) *codegurusecurity.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached codegurusecurity client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached codegurusecurity client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*codegurusecurity.Options)) (*codegurusecurity.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_codepipeline/client.go
+++ b/clients/_codepipeline/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _codepipeline provides AWS client management functions for the codepipeline
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*codepipeline.Optio
 	return client.(*codepipeline.Client), nil
 }
 
+// Must wraps the _codepipeline.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*codepipeline.Options)) *codepipeline.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached codepipeline client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached codepipeline client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*codepipeline.Options)) (*codepipeline.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_codestar/client.go
+++ b/clients/_codestar/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _codestar provides AWS client management functions for the codestar
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*codestar.Options))
 	return client.(*codestar.Client), nil
 }
 
+// Must wraps the _codestar.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*codestar.Options)) *codestar.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached codestar client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached codestar client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*codestar.Options)) (*codestar.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_codestarconnections/client.go
+++ b/clients/_codestarconnections/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _codestarconnections provides AWS client management functions for the codestarconnections
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*codestarconnection
 	return client.(*codestarconnections.Client), nil
 }
 
+// Must wraps the _codestarconnections.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*codestarconnections.Options)) *codestarconnections.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached codestarconnections client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached codestarconnections client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*codestarconnections.Options)) (*codestarconnections.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_codestarnotifications/client.go
+++ b/clients/_codestarnotifications/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _codestarnotifications provides AWS client management functions for the codestarnotifications
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*codestarnotificati
 	return client.(*codestarnotifications.Client), nil
 }
 
+// Must wraps the _codestarnotifications.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*codestarnotifications.Options)) *codestarnotifications.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached codestarnotifications client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached codestarnotifications client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*codestarnotifications.Options)) (*codestarnotifications.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cognitoidentity/client.go
+++ b/clients/_cognitoidentity/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cognitoidentity provides AWS client management functions for the cognitoidentity
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cognitoidentity.Op
 	return client.(*cognitoidentity.Client), nil
 }
 
+// Must wraps the _cognitoidentity.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cognitoidentity.Options)) *cognitoidentity.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cognitoidentity client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cognitoidentity client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cognitoidentity.Options)) (*cognitoidentity.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cognitoidentityprovider/client.go
+++ b/clients/_cognitoidentityprovider/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cognitoidentityprovider provides AWS client management functions for the cognitoidentityprovider
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cognitoidentitypro
 	return client.(*cognitoidentityprovider.Client), nil
 }
 
+// Must wraps the _cognitoidentityprovider.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cognitoidentityprovider.Options)) *cognitoidentityprovider.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cognitoidentityprovider client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cognitoidentityprovider client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_cognitosync/client.go
+++ b/clients/_cognitosync/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _cognitosync provides AWS client management functions for the cognitosync
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*cognitosync.Option
 	return client.(*cognitosync.Client), nil
 }
 
+// Must wraps the _cognitosync.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*cognitosync.Options)) *cognitosync.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached cognitosync client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached cognitosync client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*cognitosync.Options)) (*cognitosync.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_comprehend/client.go
+++ b/clients/_comprehend/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _comprehend provides AWS client management functions for the comprehend
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*comprehend.Options
 	return client.(*comprehend.Client), nil
 }
 
+// Must wraps the _comprehend.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*comprehend.Options)) *comprehend.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached comprehend client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached comprehend client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*comprehend.Options)) (*comprehend.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_comprehendmedical/client.go
+++ b/clients/_comprehendmedical/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _comprehendmedical provides AWS client management functions for the comprehendmedical
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*comprehendmedical.
 	return client.(*comprehendmedical.Client), nil
 }
 
+// Must wraps the _comprehendmedical.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*comprehendmedical.Options)) *comprehendmedical.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached comprehendmedical client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached comprehendmedical client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*comprehendmedical.Options)) (*comprehendmedical.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_computeoptimizer/client.go
+++ b/clients/_computeoptimizer/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _computeoptimizer provides AWS client management functions for the computeoptimizer
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*computeoptimizer.O
 	return client.(*computeoptimizer.Client), nil
 }
 
+// Must wraps the _computeoptimizer.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*computeoptimizer.Options)) *computeoptimizer.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached computeoptimizer client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached computeoptimizer client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*computeoptimizer.Options)) (*computeoptimizer.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_configservice/client.go
+++ b/clients/_configservice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _configservice provides AWS client management functions for the configservice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*configservice.Opti
 	return client.(*configservice.Client), nil
 }
 
+// Must wraps the _configservice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*configservice.Options)) *configservice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached configservice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached configservice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*configservice.Options)) (*configservice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_connect/client.go
+++ b/clients/_connect/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _connect provides AWS client management functions for the connect
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*connect.Options)) 
 	return client.(*connect.Client), nil
 }
 
+// Must wraps the _connect.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*connect.Options)) *connect.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached connect client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached connect client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*connect.Options)) (*connect.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_connectcampaigns/client.go
+++ b/clients/_connectcampaigns/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _connectcampaigns provides AWS client management functions for the connectcampaigns
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*connectcampaigns.O
 	return client.(*connectcampaigns.Client), nil
 }
 
+// Must wraps the _connectcampaigns.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*connectcampaigns.Options)) *connectcampaigns.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached connectcampaigns client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached connectcampaigns client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*connectcampaigns.Options)) (*connectcampaigns.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_connectcases/client.go
+++ b/clients/_connectcases/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _connectcases provides AWS client management functions for the connectcases
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*connectcases.Optio
 	return client.(*connectcases.Client), nil
 }
 
+// Must wraps the _connectcases.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*connectcases.Options)) *connectcases.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached connectcases client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached connectcases client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*connectcases.Options)) (*connectcases.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_connectcontactlens/client.go
+++ b/clients/_connectcontactlens/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _connectcontactlens provides AWS client management functions for the connectcontactlens
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*connectcontactlens
 	return client.(*connectcontactlens.Client), nil
 }
 
+// Must wraps the _connectcontactlens.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*connectcontactlens.Options)) *connectcontactlens.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached connectcontactlens client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached connectcontactlens client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*connectcontactlens.Options)) (*connectcontactlens.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_connectparticipant/client.go
+++ b/clients/_connectparticipant/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _connectparticipant provides AWS client management functions for the connectparticipant
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*connectparticipant
 	return client.(*connectparticipant.Client), nil
 }
 
+// Must wraps the _connectparticipant.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*connectparticipant.Options)) *connectparticipant.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached connectparticipant client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached connectparticipant client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*connectparticipant.Options)) (*connectparticipant.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_controltower/client.go
+++ b/clients/_controltower/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _controltower provides AWS client management functions for the controltower
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*controltower.Optio
 	return client.(*controltower.Client), nil
 }
 
+// Must wraps the _controltower.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*controltower.Options)) *controltower.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached controltower client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached controltower client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*controltower.Options)) (*controltower.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_costandusagereportservice/client.go
+++ b/clients/_costandusagereportservice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _costandusagereportservice provides AWS client management functions for the costandusagereportservice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*costandusagereport
 	return client.(*costandusagereportservice.Client), nil
 }
 
+// Must wraps the _costandusagereportservice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*costandusagereportservice.Options)) *costandusagereportservice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached costandusagereportservice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached costandusagereportservice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*costandusagereportservice.Options)) (*costandusagereportservice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_costexplorer/client.go
+++ b/clients/_costexplorer/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _costexplorer provides AWS client management functions for the costexplorer
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*costexplorer.Optio
 	return client.(*costexplorer.Client), nil
 }
 
+// Must wraps the _costexplorer.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*costexplorer.Options)) *costexplorer.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached costexplorer client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached costexplorer client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*costexplorer.Options)) (*costexplorer.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_customerprofiles/client.go
+++ b/clients/_customerprofiles/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _customerprofiles provides AWS client management functions for the customerprofiles
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*customerprofiles.O
 	return client.(*customerprofiles.Client), nil
 }
 
+// Must wraps the _customerprofiles.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*customerprofiles.Options)) *customerprofiles.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached customerprofiles client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached customerprofiles client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*customerprofiles.Options)) (*customerprofiles.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_databasemigrationservice/client.go
+++ b/clients/_databasemigrationservice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _databasemigrationservice provides AWS client management functions for the databasemigrationservice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*databasemigrations
 	return client.(*databasemigrationservice.Client), nil
 }
 
+// Must wraps the _databasemigrationservice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*databasemigrationservice.Options)) *databasemigrationservice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached databasemigrationservice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached databasemigrationservice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*databasemigrationservice.Options)) (*databasemigrationservice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_databrew/client.go
+++ b/clients/_databrew/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _databrew provides AWS client management functions for the databrew
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*databrew.Options))
 	return client.(*databrew.Client), nil
 }
 
+// Must wraps the _databrew.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*databrew.Options)) *databrew.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached databrew client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached databrew client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*databrew.Options)) (*databrew.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_dataexchange/client.go
+++ b/clients/_dataexchange/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _dataexchange provides AWS client management functions for the dataexchange
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*dataexchange.Optio
 	return client.(*dataexchange.Client), nil
 }
 
+// Must wraps the _dataexchange.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*dataexchange.Options)) *dataexchange.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached dataexchange client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached dataexchange client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*dataexchange.Options)) (*dataexchange.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_datapipeline/client.go
+++ b/clients/_datapipeline/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _datapipeline provides AWS client management functions for the datapipeline
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*datapipeline.Optio
 	return client.(*datapipeline.Client), nil
 }
 
+// Must wraps the _datapipeline.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*datapipeline.Options)) *datapipeline.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached datapipeline client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached datapipeline client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*datapipeline.Options)) (*datapipeline.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_datasync/client.go
+++ b/clients/_datasync/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _datasync provides AWS client management functions for the datasync
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*datasync.Options))
 	return client.(*datasync.Client), nil
 }
 
+// Must wraps the _datasync.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*datasync.Options)) *datasync.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached datasync client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached datasync client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*datasync.Options)) (*datasync.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_dax/client.go
+++ b/clients/_dax/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _dax provides AWS client management functions for the dax
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*dax.Options)) (*da
 	return client.(*dax.Client), nil
 }
 
+// Must wraps the _dax.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*dax.Options)) *dax.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached dax client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached dax client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*dax.Options)) (*dax.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_detective/client.go
+++ b/clients/_detective/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _detective provides AWS client management functions for the detective
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*detective.Options)
 	return client.(*detective.Client), nil
 }
 
+// Must wraps the _detective.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*detective.Options)) *detective.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached detective client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached detective client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*detective.Options)) (*detective.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_devicefarm/client.go
+++ b/clients/_devicefarm/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _devicefarm provides AWS client management functions for the devicefarm
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*devicefarm.Options
 	return client.(*devicefarm.Client), nil
 }
 
+// Must wraps the _devicefarm.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*devicefarm.Options)) *devicefarm.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached devicefarm client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached devicefarm client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*devicefarm.Options)) (*devicefarm.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_devopsguru/client.go
+++ b/clients/_devopsguru/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _devopsguru provides AWS client management functions for the devopsguru
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*devopsguru.Options
 	return client.(*devopsguru.Client), nil
 }
 
+// Must wraps the _devopsguru.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*devopsguru.Options)) *devopsguru.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached devopsguru client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached devopsguru client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*devopsguru.Options)) (*devopsguru.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_directconnect/client.go
+++ b/clients/_directconnect/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _directconnect provides AWS client management functions for the directconnect
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*directconnect.Opti
 	return client.(*directconnect.Client), nil
 }
 
+// Must wraps the _directconnect.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*directconnect.Options)) *directconnect.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached directconnect client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached directconnect client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*directconnect.Options)) (*directconnect.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_directoryservice/client.go
+++ b/clients/_directoryservice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _directoryservice provides AWS client management functions for the directoryservice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*directoryservice.O
 	return client.(*directoryservice.Client), nil
 }
 
+// Must wraps the _directoryservice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*directoryservice.Options)) *directoryservice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached directoryservice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached directoryservice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*directoryservice.Options)) (*directoryservice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_dlm/client.go
+++ b/clients/_dlm/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _dlm provides AWS client management functions for the dlm
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*dlm.Options)) (*dl
 	return client.(*dlm.Client), nil
 }
 
+// Must wraps the _dlm.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*dlm.Options)) *dlm.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached dlm client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached dlm client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*dlm.Options)) (*dlm.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_docdb/client.go
+++ b/clients/_docdb/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _docdb provides AWS client management functions for the docdb
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*docdb.Options)) (*
 	return client.(*docdb.Client), nil
 }
 
+// Must wraps the _docdb.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*docdb.Options)) *docdb.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached docdb client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached docdb client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*docdb.Options)) (*docdb.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_docdbelastic/client.go
+++ b/clients/_docdbelastic/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _docdbelastic provides AWS client management functions for the docdbelastic
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*docdbelastic.Optio
 	return client.(*docdbelastic.Client), nil
 }
 
+// Must wraps the _docdbelastic.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*docdbelastic.Options)) *docdbelastic.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached docdbelastic client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached docdbelastic client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*docdbelastic.Options)) (*docdbelastic.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_drs/client.go
+++ b/clients/_drs/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _drs provides AWS client management functions for the drs
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*drs.Options)) (*dr
 	return client.(*drs.Client), nil
 }
 
+// Must wraps the _drs.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*drs.Options)) *drs.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached drs client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached drs client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*drs.Options)) (*drs.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_dynamodb/client.go
+++ b/clients/_dynamodb/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _dynamodb provides AWS client management functions for the dynamodb
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*dynamodb.Options))
 	return client.(*dynamodb.Client), nil
 }
 
+// Must wraps the _dynamodb.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*dynamodb.Options)) *dynamodb.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached dynamodb client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached dynamodb client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*dynamodb.Options)) (*dynamodb.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_dynamodbstreams/client.go
+++ b/clients/_dynamodbstreams/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _dynamodbstreams provides AWS client management functions for the dynamodbstreams
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*dynamodbstreams.Op
 	return client.(*dynamodbstreams.Client), nil
 }
 
+// Must wraps the _dynamodbstreams.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*dynamodbstreams.Options)) *dynamodbstreams.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached dynamodbstreams client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached dynamodbstreams client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*dynamodbstreams.Options)) (*dynamodbstreams.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ebs/client.go
+++ b/clients/_ebs/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ebs provides AWS client management functions for the ebs
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ebs.Options)) (*eb
 	return client.(*ebs.Client), nil
 }
 
+// Must wraps the _ebs.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ebs.Options)) *ebs.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ebs client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ebs client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ebs.Options)) (*ebs.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ec2/client.go
+++ b/clients/_ec2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ec2 provides AWS client management functions for the ec2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ec2.Options)) (*ec
 	return client.(*ec2.Client), nil
 }
 
+// Must wraps the _ec2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ec2.Options)) *ec2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ec2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ec2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ec2.Options)) (*ec2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ec2instanceconnect/client.go
+++ b/clients/_ec2instanceconnect/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ec2instanceconnect provides AWS client management functions for the ec2instanceconnect
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ec2instanceconnect
 	return client.(*ec2instanceconnect.Client), nil
 }
 
+// Must wraps the _ec2instanceconnect.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ec2instanceconnect.Options)) *ec2instanceconnect.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ec2instanceconnect client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ec2instanceconnect client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ec2instanceconnect.Options)) (*ec2instanceconnect.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ecr/client.go
+++ b/clients/_ecr/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ecr provides AWS client management functions for the ecr
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ecr.Options)) (*ec
 	return client.(*ecr.Client), nil
 }
 
+// Must wraps the _ecr.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ecr.Options)) *ecr.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ecr client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ecr client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ecr.Options)) (*ecr.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ecrpublic/client.go
+++ b/clients/_ecrpublic/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ecrpublic provides AWS client management functions for the ecrpublic
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ecrpublic.Options)
 	return client.(*ecrpublic.Client), nil
 }
 
+// Must wraps the _ecrpublic.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ecrpublic.Options)) *ecrpublic.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ecrpublic client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ecrpublic client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ecrpublic.Options)) (*ecrpublic.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ecs/client.go
+++ b/clients/_ecs/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ecs provides AWS client management functions for the ecs
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ecs.Options)) (*ec
 	return client.(*ecs.Client), nil
 }
 
+// Must wraps the _ecs.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ecs.Options)) *ecs.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ecs client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ecs client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ecs.Options)) (*ecs.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_efs/client.go
+++ b/clients/_efs/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _efs provides AWS client management functions for the efs
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*efs.Options)) (*ef
 	return client.(*efs.Client), nil
 }
 
+// Must wraps the _efs.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*efs.Options)) *efs.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached efs client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached efs client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*efs.Options)) (*efs.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_eks/client.go
+++ b/clients/_eks/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _eks provides AWS client management functions for the eks
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*eks.Options)) (*ek
 	return client.(*eks.Client), nil
 }
 
+// Must wraps the _eks.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*eks.Options)) *eks.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached eks client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached eks client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*eks.Options)) (*eks.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_elasticache/client.go
+++ b/clients/_elasticache/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _elasticache provides AWS client management functions for the elasticache
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*elasticache.Option
 	return client.(*elasticache.Client), nil
 }
 
+// Must wraps the _elasticache.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*elasticache.Options)) *elasticache.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached elasticache client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached elasticache client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*elasticache.Options)) (*elasticache.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_elasticbeanstalk/client.go
+++ b/clients/_elasticbeanstalk/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _elasticbeanstalk provides AWS client management functions for the elasticbeanstalk
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*elasticbeanstalk.O
 	return client.(*elasticbeanstalk.Client), nil
 }
 
+// Must wraps the _elasticbeanstalk.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*elasticbeanstalk.Options)) *elasticbeanstalk.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached elasticbeanstalk client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached elasticbeanstalk client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*elasticbeanstalk.Options)) (*elasticbeanstalk.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_elasticinference/client.go
+++ b/clients/_elasticinference/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _elasticinference provides AWS client management functions for the elasticinference
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*elasticinference.O
 	return client.(*elasticinference.Client), nil
 }
 
+// Must wraps the _elasticinference.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*elasticinference.Options)) *elasticinference.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached elasticinference client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached elasticinference client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*elasticinference.Options)) (*elasticinference.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_elasticloadbalancing/client.go
+++ b/clients/_elasticloadbalancing/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _elasticloadbalancing provides AWS client management functions for the elasticloadbalancing
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*elasticloadbalanci
 	return client.(*elasticloadbalancing.Client), nil
 }
 
+// Must wraps the _elasticloadbalancing.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*elasticloadbalancing.Options)) *elasticloadbalancing.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached elasticloadbalancing client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached elasticloadbalancing client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*elasticloadbalancing.Options)) (*elasticloadbalancing.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_elasticloadbalancingv2/client.go
+++ b/clients/_elasticloadbalancingv2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _elasticloadbalancingv2 provides AWS client management functions for the elasticloadbalancingv2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*elasticloadbalanci
 	return client.(*elasticloadbalancingv2.Client), nil
 }
 
+// Must wraps the _elasticloadbalancingv2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*elasticloadbalancingv2.Options)) *elasticloadbalancingv2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached elasticloadbalancingv2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached elasticloadbalancingv2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_elasticsearchservice/client.go
+++ b/clients/_elasticsearchservice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _elasticsearchservice provides AWS client management functions for the elasticsearchservice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*elasticsearchservi
 	return client.(*elasticsearchservice.Client), nil
 }
 
+// Must wraps the _elasticsearchservice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*elasticsearchservice.Options)) *elasticsearchservice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached elasticsearchservice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached elasticsearchservice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*elasticsearchservice.Options)) (*elasticsearchservice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_elastictranscoder/client.go
+++ b/clients/_elastictranscoder/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _elastictranscoder provides AWS client management functions for the elastictranscoder
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*elastictranscoder.
 	return client.(*elastictranscoder.Client), nil
 }
 
+// Must wraps the _elastictranscoder.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*elastictranscoder.Options)) *elastictranscoder.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached elastictranscoder client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached elastictranscoder client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*elastictranscoder.Options)) (*elastictranscoder.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_emr/client.go
+++ b/clients/_emr/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _emr provides AWS client management functions for the emr
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*emr.Options)) (*em
 	return client.(*emr.Client), nil
 }
 
+// Must wraps the _emr.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*emr.Options)) *emr.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached emr client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached emr client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*emr.Options)) (*emr.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_emrcontainers/client.go
+++ b/clients/_emrcontainers/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _emrcontainers provides AWS client management functions for the emrcontainers
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*emrcontainers.Opti
 	return client.(*emrcontainers.Client), nil
 }
 
+// Must wraps the _emrcontainers.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*emrcontainers.Options)) *emrcontainers.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached emrcontainers client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached emrcontainers client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*emrcontainers.Options)) (*emrcontainers.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_emrserverless/client.go
+++ b/clients/_emrserverless/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _emrserverless provides AWS client management functions for the emrserverless
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*emrserverless.Opti
 	return client.(*emrserverless.Client), nil
 }
 
+// Must wraps the _emrserverless.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*emrserverless.Options)) *emrserverless.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached emrserverless client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached emrserverless client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*emrserverless.Options)) (*emrserverless.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_entityresolution/client.go
+++ b/clients/_entityresolution/client.go
@@ -1,0 +1,71 @@
+// AUTO-GENERATED CODE - DO NOT EDIT
+// See instructions under /codegen/README.md
+// GENERATED ON 2023-07-31 09:25:17
+
+// Package _entityresolution provides AWS client management functions for the entityresolution
+// AWS service.
+//
+// The Client() is a wrapper on entityresolution.NewFromConfig(), which creates & caches
+// the client.
+//
+// The Delete() clears the cached client.
+//
+package _entityresolution
+
+import (
+	"sync"
+
+	"github.com/TouchBistro/aws-ccp-go/providers"
+	"github.com/aws/aws-sdk-go-v2/service/entityresolution"
+)
+
+var cmap sync.Map
+
+// Client builds or returns the singleton entityresolution client for the supplied provider
+// If functional options are supplied, they are passed as-is to the underlying NewFromConfig(...)
+// for the corresponding client
+func Client(provider providers.CredsProvider, optFns ...func(*entityresolution.Options)) (*entityresolution.Client, error) {
+
+	if provider == nil {
+		return nil, providers.ErrNilProvider
+	}
+	if _, ok := cmap.Load(provider.Key()); !ok {
+		client := entityresolution.NewFromConfig(provider.Config(), optFns...)
+		cmap.Store(provider.Key(), client)
+	}
+	client, _ := cmap.Load(provider.Key())
+	return client.(*entityresolution.Client), nil
+}
+
+// Must wraps the _entityresolution.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*entityresolution.Options)) *entityresolution.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// Delete removes the cached entityresolution client for the supplied provider; This foreces the subsequent
+// calls to Client() for the same provider to recreate & return a new instnce.
+func Delete(provider providers.CredsProvider) error {
+
+	if provider == nil {
+		return providers.ErrNilProvider
+	}
+	if _, ok := cmap.Load(provider.Key()); ok {
+		cmap.Delete(provider.Key())
+	}
+	return nil
+}
+
+// Refresh discards the cached entityresolution client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*entityresolution.Options)) (*entityresolution.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
+}

--- a/clients/_eventbridge/client.go
+++ b/clients/_eventbridge/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _eventbridge provides AWS client management functions for the eventbridge
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*eventbridge.Option
 	return client.(*eventbridge.Client), nil
 }
 
+// Must wraps the _eventbridge.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*eventbridge.Options)) *eventbridge.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached eventbridge client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached eventbridge client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*eventbridge.Options)) (*eventbridge.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_evidently/client.go
+++ b/clients/_evidently/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _evidently provides AWS client management functions for the evidently
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*evidently.Options)
 	return client.(*evidently.Client), nil
 }
 
+// Must wraps the _evidently.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*evidently.Options)) *evidently.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached evidently client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached evidently client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*evidently.Options)) (*evidently.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_finspace/client.go
+++ b/clients/_finspace/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _finspace provides AWS client management functions for the finspace
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*finspace.Options))
 	return client.(*finspace.Client), nil
 }
 
+// Must wraps the _finspace.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*finspace.Options)) *finspace.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached finspace client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached finspace client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*finspace.Options)) (*finspace.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_finspacedata/client.go
+++ b/clients/_finspacedata/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _finspacedata provides AWS client management functions for the finspacedata
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*finspacedata.Optio
 	return client.(*finspacedata.Client), nil
 }
 
+// Must wraps the _finspacedata.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*finspacedata.Options)) *finspacedata.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached finspacedata client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached finspacedata client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*finspacedata.Options)) (*finspacedata.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_firehose/client.go
+++ b/clients/_firehose/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _firehose provides AWS client management functions for the firehose
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*firehose.Options))
 	return client.(*firehose.Client), nil
 }
 
+// Must wraps the _firehose.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*firehose.Options)) *firehose.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached firehose client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached firehose client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*firehose.Options)) (*firehose.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_fis/client.go
+++ b/clients/_fis/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _fis provides AWS client management functions for the fis
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*fis.Options)) (*fi
 	return client.(*fis.Client), nil
 }
 
+// Must wraps the _fis.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*fis.Options)) *fis.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached fis client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached fis client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*fis.Options)) (*fis.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_fms/client.go
+++ b/clients/_fms/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _fms provides AWS client management functions for the fms
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*fms.Options)) (*fm
 	return client.(*fms.Client), nil
 }
 
+// Must wraps the _fms.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*fms.Options)) *fms.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached fms client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached fms client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*fms.Options)) (*fms.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_forecast/client.go
+++ b/clients/_forecast/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _forecast provides AWS client management functions for the forecast
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*forecast.Options))
 	return client.(*forecast.Client), nil
 }
 
+// Must wraps the _forecast.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*forecast.Options)) *forecast.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached forecast client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached forecast client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*forecast.Options)) (*forecast.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_forecastquery/client.go
+++ b/clients/_forecastquery/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _forecastquery provides AWS client management functions for the forecastquery
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*forecastquery.Opti
 	return client.(*forecastquery.Client), nil
 }
 
+// Must wraps the _forecastquery.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*forecastquery.Options)) *forecastquery.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached forecastquery client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached forecastquery client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*forecastquery.Options)) (*forecastquery.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_frauddetector/client.go
+++ b/clients/_frauddetector/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _frauddetector provides AWS client management functions for the frauddetector
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*frauddetector.Opti
 	return client.(*frauddetector.Client), nil
 }
 
+// Must wraps the _frauddetector.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*frauddetector.Options)) *frauddetector.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached frauddetector client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached frauddetector client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*frauddetector.Options)) (*frauddetector.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_fsx/client.go
+++ b/clients/_fsx/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _fsx provides AWS client management functions for the fsx
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*fsx.Options)) (*fs
 	return client.(*fsx.Client), nil
 }
 
+// Must wraps the _fsx.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*fsx.Options)) *fsx.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached fsx client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached fsx client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*fsx.Options)) (*fsx.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_gamelift/client.go
+++ b/clients/_gamelift/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _gamelift provides AWS client management functions for the gamelift
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*gamelift.Options))
 	return client.(*gamelift.Client), nil
 }
 
+// Must wraps the _gamelift.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*gamelift.Options)) *gamelift.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached gamelift client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached gamelift client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*gamelift.Options)) (*gamelift.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_gamesparks/client.go
+++ b/clients/_gamesparks/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _gamesparks provides AWS client management functions for the gamesparks
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*gamesparks.Options
 	return client.(*gamesparks.Client), nil
 }
 
+// Must wraps the _gamesparks.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*gamesparks.Options)) *gamesparks.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached gamesparks client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached gamesparks client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*gamesparks.Options)) (*gamesparks.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_glacier/client.go
+++ b/clients/_glacier/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _glacier provides AWS client management functions for the glacier
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*glacier.Options)) 
 	return client.(*glacier.Client), nil
 }
 
+// Must wraps the _glacier.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*glacier.Options)) *glacier.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached glacier client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached glacier client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*glacier.Options)) (*glacier.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_globalaccelerator/client.go
+++ b/clients/_globalaccelerator/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _globalaccelerator provides AWS client management functions for the globalaccelerator
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*globalaccelerator.
 	return client.(*globalaccelerator.Client), nil
 }
 
+// Must wraps the _globalaccelerator.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*globalaccelerator.Options)) *globalaccelerator.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached globalaccelerator client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached globalaccelerator client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*globalaccelerator.Options)) (*globalaccelerator.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_glue/client.go
+++ b/clients/_glue/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _glue provides AWS client management functions for the glue
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*glue.Options)) (*g
 	return client.(*glue.Client), nil
 }
 
+// Must wraps the _glue.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*glue.Options)) *glue.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached glue client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached glue client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*glue.Options)) (*glue.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_grafana/client.go
+++ b/clients/_grafana/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _grafana provides AWS client management functions for the grafana
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*grafana.Options)) 
 	return client.(*grafana.Client), nil
 }
 
+// Must wraps the _grafana.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*grafana.Options)) *grafana.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached grafana client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached grafana client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*grafana.Options)) (*grafana.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_greengrass/client.go
+++ b/clients/_greengrass/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _greengrass provides AWS client management functions for the greengrass
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*greengrass.Options
 	return client.(*greengrass.Client), nil
 }
 
+// Must wraps the _greengrass.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*greengrass.Options)) *greengrass.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached greengrass client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached greengrass client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*greengrass.Options)) (*greengrass.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_greengrassv2/client.go
+++ b/clients/_greengrassv2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _greengrassv2 provides AWS client management functions for the greengrassv2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*greengrassv2.Optio
 	return client.(*greengrassv2.Client), nil
 }
 
+// Must wraps the _greengrassv2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*greengrassv2.Options)) *greengrassv2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached greengrassv2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached greengrassv2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*greengrassv2.Options)) (*greengrassv2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_groundstation/client.go
+++ b/clients/_groundstation/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _groundstation provides AWS client management functions for the groundstation
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*groundstation.Opti
 	return client.(*groundstation.Client), nil
 }
 
+// Must wraps the _groundstation.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*groundstation.Options)) *groundstation.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached groundstation client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached groundstation client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*groundstation.Options)) (*groundstation.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_guardduty/client.go
+++ b/clients/_guardduty/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _guardduty provides AWS client management functions for the guardduty
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*guardduty.Options)
 	return client.(*guardduty.Client), nil
 }
 
+// Must wraps the _guardduty.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*guardduty.Options)) *guardduty.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached guardduty client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached guardduty client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*guardduty.Options)) (*guardduty.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_health/client.go
+++ b/clients/_health/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _health provides AWS client management functions for the health
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*health.Options)) (
 	return client.(*health.Client), nil
 }
 
+// Must wraps the _health.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*health.Options)) *health.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached health client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached health client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*health.Options)) (*health.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_healthlake/client.go
+++ b/clients/_healthlake/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _healthlake provides AWS client management functions for the healthlake
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*healthlake.Options
 	return client.(*healthlake.Client), nil
 }
 
+// Must wraps the _healthlake.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*healthlake.Options)) *healthlake.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached healthlake client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached healthlake client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*healthlake.Options)) (*healthlake.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_honeycode/client.go
+++ b/clients/_honeycode/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _honeycode provides AWS client management functions for the honeycode
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*honeycode.Options)
 	return client.(*honeycode.Client), nil
 }
 
+// Must wraps the _honeycode.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*honeycode.Options)) *honeycode.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached honeycode client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached honeycode client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*honeycode.Options)) (*honeycode.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iam/client.go
+++ b/clients/_iam/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iam provides AWS client management functions for the iam
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iam.Options)) (*ia
 	return client.(*iam.Client), nil
 }
 
+// Must wraps the _iam.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iam.Options)) *iam.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iam client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iam client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iam.Options)) (*iam.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_identitystore/client.go
+++ b/clients/_identitystore/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _identitystore provides AWS client management functions for the identitystore
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*identitystore.Opti
 	return client.(*identitystore.Client), nil
 }
 
+// Must wraps the _identitystore.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*identitystore.Options)) *identitystore.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached identitystore client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached identitystore client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*identitystore.Options)) (*identitystore.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_imagebuilder/client.go
+++ b/clients/_imagebuilder/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _imagebuilder provides AWS client management functions for the imagebuilder
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*imagebuilder.Optio
 	return client.(*imagebuilder.Client), nil
 }
 
+// Must wraps the _imagebuilder.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*imagebuilder.Options)) *imagebuilder.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached imagebuilder client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached imagebuilder client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*imagebuilder.Options)) (*imagebuilder.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_inspector/client.go
+++ b/clients/_inspector/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _inspector provides AWS client management functions for the inspector
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*inspector.Options)
 	return client.(*inspector.Client), nil
 }
 
+// Must wraps the _inspector.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*inspector.Options)) *inspector.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached inspector client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached inspector client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*inspector.Options)) (*inspector.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_inspector2/client.go
+++ b/clients/_inspector2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _inspector2 provides AWS client management functions for the inspector2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*inspector2.Options
 	return client.(*inspector2.Client), nil
 }
 
+// Must wraps the _inspector2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*inspector2.Options)) *inspector2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached inspector2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached inspector2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*inspector2.Options)) (*inspector2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_internetmonitor/client.go
+++ b/clients/_internetmonitor/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _internetmonitor provides AWS client management functions for the internetmonitor
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*internetmonitor.Op
 	return client.(*internetmonitor.Client), nil
 }
 
+// Must wraps the _internetmonitor.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*internetmonitor.Options)) *internetmonitor.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached internetmonitor client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached internetmonitor client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*internetmonitor.Options)) (*internetmonitor.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iot/client.go
+++ b/clients/_iot/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iot provides AWS client management functions for the iot
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iot.Options)) (*io
 	return client.(*iot.Client), nil
 }
 
+// Must wraps the _iot.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iot.Options)) *iot.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iot client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iot client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iot.Options)) (*iot.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iot1clickdevicesservice/client.go
+++ b/clients/_iot1clickdevicesservice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iot1clickdevicesservice provides AWS client management functions for the iot1clickdevicesservice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iot1clickdevicesse
 	return client.(*iot1clickdevicesservice.Client), nil
 }
 
+// Must wraps the _iot1clickdevicesservice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iot1clickdevicesservice.Options)) *iot1clickdevicesservice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iot1clickdevicesservice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iot1clickdevicesservice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iot1clickdevicesservice.Options)) (*iot1clickdevicesservice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iot1clickprojects/client.go
+++ b/clients/_iot1clickprojects/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iot1clickprojects provides AWS client management functions for the iot1clickprojects
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iot1clickprojects.
 	return client.(*iot1clickprojects.Client), nil
 }
 
+// Must wraps the _iot1clickprojects.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iot1clickprojects.Options)) *iot1clickprojects.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iot1clickprojects client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iot1clickprojects client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iot1clickprojects.Options)) (*iot1clickprojects.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iotanalytics/client.go
+++ b/clients/_iotanalytics/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iotanalytics provides AWS client management functions for the iotanalytics
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iotanalytics.Optio
 	return client.(*iotanalytics.Client), nil
 }
 
+// Must wraps the _iotanalytics.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iotanalytics.Options)) *iotanalytics.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iotanalytics client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iotanalytics client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iotanalytics.Options)) (*iotanalytics.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iotdataplane/client.go
+++ b/clients/_iotdataplane/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iotdataplane provides AWS client management functions for the iotdataplane
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iotdataplane.Optio
 	return client.(*iotdataplane.Client), nil
 }
 
+// Must wraps the _iotdataplane.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iotdataplane.Options)) *iotdataplane.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iotdataplane client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iotdataplane client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iotdataplane.Options)) (*iotdataplane.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iotdeviceadvisor/client.go
+++ b/clients/_iotdeviceadvisor/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iotdeviceadvisor provides AWS client management functions for the iotdeviceadvisor
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iotdeviceadvisor.O
 	return client.(*iotdeviceadvisor.Client), nil
 }
 
+// Must wraps the _iotdeviceadvisor.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iotdeviceadvisor.Options)) *iotdeviceadvisor.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iotdeviceadvisor client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iotdeviceadvisor client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iotdeviceadvisor.Options)) (*iotdeviceadvisor.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iotevents/client.go
+++ b/clients/_iotevents/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iotevents provides AWS client management functions for the iotevents
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iotevents.Options)
 	return client.(*iotevents.Client), nil
 }
 
+// Must wraps the _iotevents.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iotevents.Options)) *iotevents.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iotevents client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iotevents client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iotevents.Options)) (*iotevents.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ioteventsdata/client.go
+++ b/clients/_ioteventsdata/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ioteventsdata provides AWS client management functions for the ioteventsdata
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ioteventsdata.Opti
 	return client.(*ioteventsdata.Client), nil
 }
 
+// Must wraps the _ioteventsdata.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ioteventsdata.Options)) *ioteventsdata.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ioteventsdata client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ioteventsdata client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ioteventsdata.Options)) (*ioteventsdata.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iotfleethub/client.go
+++ b/clients/_iotfleethub/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iotfleethub provides AWS client management functions for the iotfleethub
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iotfleethub.Option
 	return client.(*iotfleethub.Client), nil
 }
 
+// Must wraps the _iotfleethub.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iotfleethub.Options)) *iotfleethub.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iotfleethub client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iotfleethub client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iotfleethub.Options)) (*iotfleethub.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iotfleetwise/client.go
+++ b/clients/_iotfleetwise/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iotfleetwise provides AWS client management functions for the iotfleetwise
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iotfleetwise.Optio
 	return client.(*iotfleetwise.Client), nil
 }
 
+// Must wraps the _iotfleetwise.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iotfleetwise.Options)) *iotfleetwise.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iotfleetwise client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iotfleetwise client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iotfleetwise.Options)) (*iotfleetwise.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iotjobsdataplane/client.go
+++ b/clients/_iotjobsdataplane/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iotjobsdataplane provides AWS client management functions for the iotjobsdataplane
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iotjobsdataplane.O
 	return client.(*iotjobsdataplane.Client), nil
 }
 
+// Must wraps the _iotjobsdataplane.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iotjobsdataplane.Options)) *iotjobsdataplane.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iotjobsdataplane client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iotjobsdataplane client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iotjobsdataplane.Options)) (*iotjobsdataplane.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iotroborunner/client.go
+++ b/clients/_iotroborunner/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iotroborunner provides AWS client management functions for the iotroborunner
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iotroborunner.Opti
 	return client.(*iotroborunner.Client), nil
 }
 
+// Must wraps the _iotroborunner.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iotroborunner.Options)) *iotroborunner.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iotroborunner client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iotroborunner client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iotroborunner.Options)) (*iotroborunner.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iotsecuretunneling/client.go
+++ b/clients/_iotsecuretunneling/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iotsecuretunneling provides AWS client management functions for the iotsecuretunneling
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iotsecuretunneling
 	return client.(*iotsecuretunneling.Client), nil
 }
 
+// Must wraps the _iotsecuretunneling.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iotsecuretunneling.Options)) *iotsecuretunneling.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iotsecuretunneling client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iotsecuretunneling client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iotsecuretunneling.Options)) (*iotsecuretunneling.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iotsitewise/client.go
+++ b/clients/_iotsitewise/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iotsitewise provides AWS client management functions for the iotsitewise
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iotsitewise.Option
 	return client.(*iotsitewise.Client), nil
 }
 
+// Must wraps the _iotsitewise.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iotsitewise.Options)) *iotsitewise.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iotsitewise client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iotsitewise client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iotsitewise.Options)) (*iotsitewise.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iotthingsgraph/client.go
+++ b/clients/_iotthingsgraph/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iotthingsgraph provides AWS client management functions for the iotthingsgraph
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iotthingsgraph.Opt
 	return client.(*iotthingsgraph.Client), nil
 }
 
+// Must wraps the _iotthingsgraph.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iotthingsgraph.Options)) *iotthingsgraph.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iotthingsgraph client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iotthingsgraph client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iotthingsgraph.Options)) (*iotthingsgraph.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iottwinmaker/client.go
+++ b/clients/_iottwinmaker/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iottwinmaker provides AWS client management functions for the iottwinmaker
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iottwinmaker.Optio
 	return client.(*iottwinmaker.Client), nil
 }
 
+// Must wraps the _iottwinmaker.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iottwinmaker.Options)) *iottwinmaker.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iottwinmaker client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iottwinmaker client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iottwinmaker.Options)) (*iottwinmaker.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_iotwireless/client.go
+++ b/clients/_iotwireless/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _iotwireless provides AWS client management functions for the iotwireless
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*iotwireless.Option
 	return client.(*iotwireless.Client), nil
 }
 
+// Must wraps the _iotwireless.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*iotwireless.Options)) *iotwireless.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached iotwireless client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached iotwireless client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*iotwireless.Options)) (*iotwireless.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ivs/client.go
+++ b/clients/_ivs/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ivs provides AWS client management functions for the ivs
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ivs.Options)) (*iv
 	return client.(*ivs.Client), nil
 }
 
+// Must wraps the _ivs.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ivs.Options)) *ivs.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ivs client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ivs client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ivs.Options)) (*ivs.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ivschat/client.go
+++ b/clients/_ivschat/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ivschat provides AWS client management functions for the ivschat
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ivschat.Options)) 
 	return client.(*ivschat.Client), nil
 }
 
+// Must wraps the _ivschat.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ivschat.Options)) *ivschat.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ivschat client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ivschat client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ivschat.Options)) (*ivschat.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ivsrealtime/client.go
+++ b/clients/_ivsrealtime/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ivsrealtime provides AWS client management functions for the ivsrealtime
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ivsrealtime.Option
 	return client.(*ivsrealtime.Client), nil
 }
 
+// Must wraps the _ivsrealtime.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ivsrealtime.Options)) *ivsrealtime.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ivsrealtime client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ivsrealtime client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ivsrealtime.Options)) (*ivsrealtime.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kafka/client.go
+++ b/clients/_kafka/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kafka provides AWS client management functions for the kafka
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kafka.Options)) (*
 	return client.(*kafka.Client), nil
 }
 
+// Must wraps the _kafka.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kafka.Options)) *kafka.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kafka client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kafka client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kafka.Options)) (*kafka.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kafkaconnect/client.go
+++ b/clients/_kafkaconnect/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kafkaconnect provides AWS client management functions for the kafkaconnect
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kafkaconnect.Optio
 	return client.(*kafkaconnect.Client), nil
 }
 
+// Must wraps the _kafkaconnect.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kafkaconnect.Options)) *kafkaconnect.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kafkaconnect client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kafkaconnect client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kafkaconnect.Options)) (*kafkaconnect.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kendra/client.go
+++ b/clients/_kendra/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kendra provides AWS client management functions for the kendra
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kendra.Options)) (
 	return client.(*kendra.Client), nil
 }
 
+// Must wraps the _kendra.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kendra.Options)) *kendra.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kendra client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kendra client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kendra.Options)) (*kendra.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kendraranking/client.go
+++ b/clients/_kendraranking/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kendraranking provides AWS client management functions for the kendraranking
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kendraranking.Opti
 	return client.(*kendraranking.Client), nil
 }
 
+// Must wraps the _kendraranking.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kendraranking.Options)) *kendraranking.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kendraranking client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kendraranking client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kendraranking.Options)) (*kendraranking.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_keyspaces/client.go
+++ b/clients/_keyspaces/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _keyspaces provides AWS client management functions for the keyspaces
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*keyspaces.Options)
 	return client.(*keyspaces.Client), nil
 }
 
+// Must wraps the _keyspaces.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*keyspaces.Options)) *keyspaces.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached keyspaces client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached keyspaces client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*keyspaces.Options)) (*keyspaces.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kinesis/client.go
+++ b/clients/_kinesis/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kinesis provides AWS client management functions for the kinesis
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kinesis.Options)) 
 	return client.(*kinesis.Client), nil
 }
 
+// Must wraps the _kinesis.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kinesis.Options)) *kinesis.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kinesis client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kinesis client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kinesis.Options)) (*kinesis.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kinesisanalytics/client.go
+++ b/clients/_kinesisanalytics/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kinesisanalytics provides AWS client management functions for the kinesisanalytics
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kinesisanalytics.O
 	return client.(*kinesisanalytics.Client), nil
 }
 
+// Must wraps the _kinesisanalytics.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kinesisanalytics.Options)) *kinesisanalytics.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kinesisanalytics client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kinesisanalytics client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kinesisanalytics.Options)) (*kinesisanalytics.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kinesisanalyticsv2/client.go
+++ b/clients/_kinesisanalyticsv2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kinesisanalyticsv2 provides AWS client management functions for the kinesisanalyticsv2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kinesisanalyticsv2
 	return client.(*kinesisanalyticsv2.Client), nil
 }
 
+// Must wraps the _kinesisanalyticsv2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kinesisanalyticsv2.Options)) *kinesisanalyticsv2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kinesisanalyticsv2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kinesisanalyticsv2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kinesisanalyticsv2.Options)) (*kinesisanalyticsv2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kinesisvideo/client.go
+++ b/clients/_kinesisvideo/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kinesisvideo provides AWS client management functions for the kinesisvideo
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kinesisvideo.Optio
 	return client.(*kinesisvideo.Client), nil
 }
 
+// Must wraps the _kinesisvideo.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kinesisvideo.Options)) *kinesisvideo.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kinesisvideo client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kinesisvideo client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kinesisvideo.Options)) (*kinesisvideo.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kinesisvideoarchivedmedia/client.go
+++ b/clients/_kinesisvideoarchivedmedia/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kinesisvideoarchivedmedia provides AWS client management functions for the kinesisvideoarchivedmedia
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kinesisvideoarchiv
 	return client.(*kinesisvideoarchivedmedia.Client), nil
 }
 
+// Must wraps the _kinesisvideoarchivedmedia.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kinesisvideoarchivedmedia.Options)) *kinesisvideoarchivedmedia.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kinesisvideoarchivedmedia client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kinesisvideoarchivedmedia client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kinesisvideoarchivedmedia.Options)) (*kinesisvideoarchivedmedia.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kinesisvideomedia/client.go
+++ b/clients/_kinesisvideomedia/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kinesisvideomedia provides AWS client management functions for the kinesisvideomedia
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kinesisvideomedia.
 	return client.(*kinesisvideomedia.Client), nil
 }
 
+// Must wraps the _kinesisvideomedia.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kinesisvideomedia.Options)) *kinesisvideomedia.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kinesisvideomedia client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kinesisvideomedia client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kinesisvideomedia.Options)) (*kinesisvideomedia.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kinesisvideosignaling/client.go
+++ b/clients/_kinesisvideosignaling/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kinesisvideosignaling provides AWS client management functions for the kinesisvideosignaling
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kinesisvideosignal
 	return client.(*kinesisvideosignaling.Client), nil
 }
 
+// Must wraps the _kinesisvideosignaling.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kinesisvideosignaling.Options)) *kinesisvideosignaling.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kinesisvideosignaling client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kinesisvideosignaling client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kinesisvideosignaling.Options)) (*kinesisvideosignaling.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kinesisvideowebrtcstorage/client.go
+++ b/clients/_kinesisvideowebrtcstorage/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kinesisvideowebrtcstorage provides AWS client management functions for the kinesisvideowebrtcstorage
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kinesisvideowebrtc
 	return client.(*kinesisvideowebrtcstorage.Client), nil
 }
 
+// Must wraps the _kinesisvideowebrtcstorage.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kinesisvideowebrtcstorage.Options)) *kinesisvideowebrtcstorage.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kinesisvideowebrtcstorage client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kinesisvideowebrtcstorage client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kinesisvideowebrtcstorage.Options)) (*kinesisvideowebrtcstorage.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_kms/client.go
+++ b/clients/_kms/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _kms provides AWS client management functions for the kms
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*kms.Options)) (*km
 	return client.(*kms.Client), nil
 }
 
+// Must wraps the _kms.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*kms.Options)) *kms.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached kms client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached kms client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*kms.Options)) (*kms.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_lakeformation/client.go
+++ b/clients/_lakeformation/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _lakeformation provides AWS client management functions for the lakeformation
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*lakeformation.Opti
 	return client.(*lakeformation.Client), nil
 }
 
+// Must wraps the _lakeformation.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*lakeformation.Options)) *lakeformation.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached lakeformation client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached lakeformation client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*lakeformation.Options)) (*lakeformation.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_lambda/client.go
+++ b/clients/_lambda/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _lambda provides AWS client management functions for the lambda
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*lambda.Options)) (
 	return client.(*lambda.Client), nil
 }
 
+// Must wraps the _lambda.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*lambda.Options)) *lambda.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached lambda client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached lambda client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*lambda.Options)) (*lambda.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_lexmodelbuildingservice/client.go
+++ b/clients/_lexmodelbuildingservice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _lexmodelbuildingservice provides AWS client management functions for the lexmodelbuildingservice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*lexmodelbuildingse
 	return client.(*lexmodelbuildingservice.Client), nil
 }
 
+// Must wraps the _lexmodelbuildingservice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*lexmodelbuildingservice.Options)) *lexmodelbuildingservice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached lexmodelbuildingservice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached lexmodelbuildingservice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*lexmodelbuildingservice.Options)) (*lexmodelbuildingservice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_lexmodelsv2/client.go
+++ b/clients/_lexmodelsv2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _lexmodelsv2 provides AWS client management functions for the lexmodelsv2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*lexmodelsv2.Option
 	return client.(*lexmodelsv2.Client), nil
 }
 
+// Must wraps the _lexmodelsv2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*lexmodelsv2.Options)) *lexmodelsv2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached lexmodelsv2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached lexmodelsv2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*lexmodelsv2.Options)) (*lexmodelsv2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_lexruntimeservice/client.go
+++ b/clients/_lexruntimeservice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _lexruntimeservice provides AWS client management functions for the lexruntimeservice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*lexruntimeservice.
 	return client.(*lexruntimeservice.Client), nil
 }
 
+// Must wraps the _lexruntimeservice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*lexruntimeservice.Options)) *lexruntimeservice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached lexruntimeservice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached lexruntimeservice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*lexruntimeservice.Options)) (*lexruntimeservice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_lexruntimev2/client.go
+++ b/clients/_lexruntimev2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _lexruntimev2 provides AWS client management functions for the lexruntimev2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*lexruntimev2.Optio
 	return client.(*lexruntimev2.Client), nil
 }
 
+// Must wraps the _lexruntimev2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*lexruntimev2.Options)) *lexruntimev2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached lexruntimev2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached lexruntimev2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*lexruntimev2.Options)) (*lexruntimev2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_licensemanager/client.go
+++ b/clients/_licensemanager/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _licensemanager provides AWS client management functions for the licensemanager
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*licensemanager.Opt
 	return client.(*licensemanager.Client), nil
 }
 
+// Must wraps the _licensemanager.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*licensemanager.Options)) *licensemanager.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached licensemanager client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached licensemanager client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*licensemanager.Options)) (*licensemanager.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_licensemanagerlinuxsubscriptions/client.go
+++ b/clients/_licensemanagerlinuxsubscriptions/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _licensemanagerlinuxsubscriptions provides AWS client management functions for the licensemanagerlinuxsubscriptions
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*licensemanagerlinu
 	return client.(*licensemanagerlinuxsubscriptions.Client), nil
 }
 
+// Must wraps the _licensemanagerlinuxsubscriptions.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*licensemanagerlinuxsubscriptions.Options)) *licensemanagerlinuxsubscriptions.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached licensemanagerlinuxsubscriptions client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached licensemanagerlinuxsubscriptions client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*licensemanagerlinuxsubscriptions.Options)) (*licensemanagerlinuxsubscriptions.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_licensemanagerusersubscriptions/client.go
+++ b/clients/_licensemanagerusersubscriptions/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _licensemanagerusersubscriptions provides AWS client management functions for the licensemanagerusersubscriptions
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*licensemanageruser
 	return client.(*licensemanagerusersubscriptions.Client), nil
 }
 
+// Must wraps the _licensemanagerusersubscriptions.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*licensemanagerusersubscriptions.Options)) *licensemanagerusersubscriptions.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached licensemanagerusersubscriptions client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached licensemanagerusersubscriptions client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*licensemanagerusersubscriptions.Options)) (*licensemanagerusersubscriptions.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_lightsail/client.go
+++ b/clients/_lightsail/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _lightsail provides AWS client management functions for the lightsail
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*lightsail.Options)
 	return client.(*lightsail.Client), nil
 }
 
+// Must wraps the _lightsail.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*lightsail.Options)) *lightsail.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached lightsail client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached lightsail client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*lightsail.Options)) (*lightsail.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_location/client.go
+++ b/clients/_location/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _location provides AWS client management functions for the location
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*location.Options))
 	return client.(*location.Client), nil
 }
 
+// Must wraps the _location.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*location.Options)) *location.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached location client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached location client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*location.Options)) (*location.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_lookoutequipment/client.go
+++ b/clients/_lookoutequipment/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _lookoutequipment provides AWS client management functions for the lookoutequipment
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*lookoutequipment.O
 	return client.(*lookoutequipment.Client), nil
 }
 
+// Must wraps the _lookoutequipment.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*lookoutequipment.Options)) *lookoutequipment.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached lookoutequipment client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached lookoutequipment client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*lookoutequipment.Options)) (*lookoutequipment.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_lookoutmetrics/client.go
+++ b/clients/_lookoutmetrics/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _lookoutmetrics provides AWS client management functions for the lookoutmetrics
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*lookoutmetrics.Opt
 	return client.(*lookoutmetrics.Client), nil
 }
 
+// Must wraps the _lookoutmetrics.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*lookoutmetrics.Options)) *lookoutmetrics.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached lookoutmetrics client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached lookoutmetrics client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*lookoutmetrics.Options)) (*lookoutmetrics.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_lookoutvision/client.go
+++ b/clients/_lookoutvision/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _lookoutvision provides AWS client management functions for the lookoutvision
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*lookoutvision.Opti
 	return client.(*lookoutvision.Client), nil
 }
 
+// Must wraps the _lookoutvision.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*lookoutvision.Options)) *lookoutvision.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached lookoutvision client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached lookoutvision client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*lookoutvision.Options)) (*lookoutvision.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_m2/client.go
+++ b/clients/_m2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _m2 provides AWS client management functions for the m2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*m2.Options)) (*m2.
 	return client.(*m2.Client), nil
 }
 
+// Must wraps the _m2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*m2.Options)) *m2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached m2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached m2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*m2.Options)) (*m2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_machinelearning/client.go
+++ b/clients/_machinelearning/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _machinelearning provides AWS client management functions for the machinelearning
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*machinelearning.Op
 	return client.(*machinelearning.Client), nil
 }
 
+// Must wraps the _machinelearning.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*machinelearning.Options)) *machinelearning.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached machinelearning client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached machinelearning client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*machinelearning.Options)) (*machinelearning.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_macie/client.go
+++ b/clients/_macie/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _macie provides AWS client management functions for the macie
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*macie.Options)) (*
 	return client.(*macie.Client), nil
 }
 
+// Must wraps the _macie.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*macie.Options)) *macie.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached macie client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached macie client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*macie.Options)) (*macie.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_macie2/client.go
+++ b/clients/_macie2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _macie2 provides AWS client management functions for the macie2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*macie2.Options)) (
 	return client.(*macie2.Client), nil
 }
 
+// Must wraps the _macie2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*macie2.Options)) *macie2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached macie2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached macie2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*macie2.Options)) (*macie2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_managedblockchain/client.go
+++ b/clients/_managedblockchain/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _managedblockchain provides AWS client management functions for the managedblockchain
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*managedblockchain.
 	return client.(*managedblockchain.Client), nil
 }
 
+// Must wraps the _managedblockchain.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*managedblockchain.Options)) *managedblockchain.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached managedblockchain client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached managedblockchain client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*managedblockchain.Options)) (*managedblockchain.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_managedblockchainquery/client.go
+++ b/clients/_managedblockchainquery/client.go
@@ -1,0 +1,71 @@
+// AUTO-GENERATED CODE - DO NOT EDIT
+// See instructions under /codegen/README.md
+// GENERATED ON 2023-07-31 09:25:17
+
+// Package _managedblockchainquery provides AWS client management functions for the managedblockchainquery
+// AWS service.
+//
+// The Client() is a wrapper on managedblockchainquery.NewFromConfig(), which creates & caches
+// the client.
+//
+// The Delete() clears the cached client.
+//
+package _managedblockchainquery
+
+import (
+	"sync"
+
+	"github.com/TouchBistro/aws-ccp-go/providers"
+	"github.com/aws/aws-sdk-go-v2/service/managedblockchainquery"
+)
+
+var cmap sync.Map
+
+// Client builds or returns the singleton managedblockchainquery client for the supplied provider
+// If functional options are supplied, they are passed as-is to the underlying NewFromConfig(...)
+// for the corresponding client
+func Client(provider providers.CredsProvider, optFns ...func(*managedblockchainquery.Options)) (*managedblockchainquery.Client, error) {
+
+	if provider == nil {
+		return nil, providers.ErrNilProvider
+	}
+	if _, ok := cmap.Load(provider.Key()); !ok {
+		client := managedblockchainquery.NewFromConfig(provider.Config(), optFns...)
+		cmap.Store(provider.Key(), client)
+	}
+	client, _ := cmap.Load(provider.Key())
+	return client.(*managedblockchainquery.Client), nil
+}
+
+// Must wraps the _managedblockchainquery.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*managedblockchainquery.Options)) *managedblockchainquery.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// Delete removes the cached managedblockchainquery client for the supplied provider; This foreces the subsequent
+// calls to Client() for the same provider to recreate & return a new instnce.
+func Delete(provider providers.CredsProvider) error {
+
+	if provider == nil {
+		return providers.ErrNilProvider
+	}
+	if _, ok := cmap.Load(provider.Key()); ok {
+		cmap.Delete(provider.Key())
+	}
+	return nil
+}
+
+// Refresh discards the cached managedblockchainquery client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*managedblockchainquery.Options)) (*managedblockchainquery.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
+}

--- a/clients/_marketplacecatalog/client.go
+++ b/clients/_marketplacecatalog/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _marketplacecatalog provides AWS client management functions for the marketplacecatalog
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*marketplacecatalog
 	return client.(*marketplacecatalog.Client), nil
 }
 
+// Must wraps the _marketplacecatalog.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*marketplacecatalog.Options)) *marketplacecatalog.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached marketplacecatalog client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached marketplacecatalog client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*marketplacecatalog.Options)) (*marketplacecatalog.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_marketplacecommerceanalytics/client.go
+++ b/clients/_marketplacecommerceanalytics/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _marketplacecommerceanalytics provides AWS client management functions for the marketplacecommerceanalytics
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*marketplacecommerc
 	return client.(*marketplacecommerceanalytics.Client), nil
 }
 
+// Must wraps the _marketplacecommerceanalytics.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*marketplacecommerceanalytics.Options)) *marketplacecommerceanalytics.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached marketplacecommerceanalytics client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached marketplacecommerceanalytics client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*marketplacecommerceanalytics.Options)) (*marketplacecommerceanalytics.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_marketplaceentitlementservice/client.go
+++ b/clients/_marketplaceentitlementservice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _marketplaceentitlementservice provides AWS client management functions for the marketplaceentitlementservice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*marketplaceentitle
 	return client.(*marketplaceentitlementservice.Client), nil
 }
 
+// Must wraps the _marketplaceentitlementservice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*marketplaceentitlementservice.Options)) *marketplaceentitlementservice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached marketplaceentitlementservice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached marketplaceentitlementservice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*marketplaceentitlementservice.Options)) (*marketplaceentitlementservice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_marketplacemetering/client.go
+++ b/clients/_marketplacemetering/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _marketplacemetering provides AWS client management functions for the marketplacemetering
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*marketplacemeterin
 	return client.(*marketplacemetering.Client), nil
 }
 
+// Must wraps the _marketplacemetering.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*marketplacemetering.Options)) *marketplacemetering.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached marketplacemetering client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached marketplacemetering client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*marketplacemetering.Options)) (*marketplacemetering.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mediaconnect/client.go
+++ b/clients/_mediaconnect/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mediaconnect provides AWS client management functions for the mediaconnect
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mediaconnect.Optio
 	return client.(*mediaconnect.Client), nil
 }
 
+// Must wraps the _mediaconnect.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mediaconnect.Options)) *mediaconnect.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mediaconnect client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mediaconnect client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mediaconnect.Options)) (*mediaconnect.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mediaconvert/client.go
+++ b/clients/_mediaconvert/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mediaconvert provides AWS client management functions for the mediaconvert
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mediaconvert.Optio
 	return client.(*mediaconvert.Client), nil
 }
 
+// Must wraps the _mediaconvert.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mediaconvert.Options)) *mediaconvert.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mediaconvert client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mediaconvert client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mediaconvert.Options)) (*mediaconvert.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_medialive/client.go
+++ b/clients/_medialive/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _medialive provides AWS client management functions for the medialive
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*medialive.Options)
 	return client.(*medialive.Client), nil
 }
 
+// Must wraps the _medialive.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*medialive.Options)) *medialive.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached medialive client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached medialive client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*medialive.Options)) (*medialive.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mediapackage/client.go
+++ b/clients/_mediapackage/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mediapackage provides AWS client management functions for the mediapackage
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mediapackage.Optio
 	return client.(*mediapackage.Client), nil
 }
 
+// Must wraps the _mediapackage.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mediapackage.Options)) *mediapackage.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mediapackage client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mediapackage client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mediapackage.Options)) (*mediapackage.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mediapackagev2/client.go
+++ b/clients/_mediapackagev2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mediapackagev2 provides AWS client management functions for the mediapackagev2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mediapackagev2.Opt
 	return client.(*mediapackagev2.Client), nil
 }
 
+// Must wraps the _mediapackagev2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mediapackagev2.Options)) *mediapackagev2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mediapackagev2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mediapackagev2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mediapackagev2.Options)) (*mediapackagev2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mediapackagevod/client.go
+++ b/clients/_mediapackagevod/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mediapackagevod provides AWS client management functions for the mediapackagevod
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mediapackagevod.Op
 	return client.(*mediapackagevod.Client), nil
 }
 
+// Must wraps the _mediapackagevod.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mediapackagevod.Options)) *mediapackagevod.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mediapackagevod client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mediapackagevod client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mediapackagevod.Options)) (*mediapackagevod.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mediastore/client.go
+++ b/clients/_mediastore/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mediastore provides AWS client management functions for the mediastore
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mediastore.Options
 	return client.(*mediastore.Client), nil
 }
 
+// Must wraps the _mediastore.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mediastore.Options)) *mediastore.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mediastore client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mediastore client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mediastore.Options)) (*mediastore.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mediastoredata/client.go
+++ b/clients/_mediastoredata/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mediastoredata provides AWS client management functions for the mediastoredata
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mediastoredata.Opt
 	return client.(*mediastoredata.Client), nil
 }
 
+// Must wraps the _mediastoredata.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mediastoredata.Options)) *mediastoredata.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mediastoredata client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mediastoredata client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mediastoredata.Options)) (*mediastoredata.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mediatailor/client.go
+++ b/clients/_mediatailor/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mediatailor provides AWS client management functions for the mediatailor
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mediatailor.Option
 	return client.(*mediatailor.Client), nil
 }
 
+// Must wraps the _mediatailor.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mediatailor.Options)) *mediatailor.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mediatailor client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mediatailor client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mediatailor.Options)) (*mediatailor.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_medicalimaging/client.go
+++ b/clients/_medicalimaging/client.go
@@ -1,0 +1,71 @@
+// AUTO-GENERATED CODE - DO NOT EDIT
+// See instructions under /codegen/README.md
+// GENERATED ON 2023-07-31 09:25:17
+
+// Package _medicalimaging provides AWS client management functions for the medicalimaging
+// AWS service.
+//
+// The Client() is a wrapper on medicalimaging.NewFromConfig(), which creates & caches
+// the client.
+//
+// The Delete() clears the cached client.
+//
+package _medicalimaging
+
+import (
+	"sync"
+
+	"github.com/TouchBistro/aws-ccp-go/providers"
+	"github.com/aws/aws-sdk-go-v2/service/medicalimaging"
+)
+
+var cmap sync.Map
+
+// Client builds or returns the singleton medicalimaging client for the supplied provider
+// If functional options are supplied, they are passed as-is to the underlying NewFromConfig(...)
+// for the corresponding client
+func Client(provider providers.CredsProvider, optFns ...func(*medicalimaging.Options)) (*medicalimaging.Client, error) {
+
+	if provider == nil {
+		return nil, providers.ErrNilProvider
+	}
+	if _, ok := cmap.Load(provider.Key()); !ok {
+		client := medicalimaging.NewFromConfig(provider.Config(), optFns...)
+		cmap.Store(provider.Key(), client)
+	}
+	client, _ := cmap.Load(provider.Key())
+	return client.(*medicalimaging.Client), nil
+}
+
+// Must wraps the _medicalimaging.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*medicalimaging.Options)) *medicalimaging.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// Delete removes the cached medicalimaging client for the supplied provider; This foreces the subsequent
+// calls to Client() for the same provider to recreate & return a new instnce.
+func Delete(provider providers.CredsProvider) error {
+
+	if provider == nil {
+		return providers.ErrNilProvider
+	}
+	if _, ok := cmap.Load(provider.Key()); ok {
+		cmap.Delete(provider.Key())
+	}
+	return nil
+}
+
+// Refresh discards the cached medicalimaging client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*medicalimaging.Options)) (*medicalimaging.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
+}

--- a/clients/_memorydb/client.go
+++ b/clients/_memorydb/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _memorydb provides AWS client management functions for the memorydb
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*memorydb.Options))
 	return client.(*memorydb.Client), nil
 }
 
+// Must wraps the _memorydb.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*memorydb.Options)) *memorydb.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached memorydb client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached memorydb client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*memorydb.Options)) (*memorydb.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mgn/client.go
+++ b/clients/_mgn/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mgn provides AWS client management functions for the mgn
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mgn.Options)) (*mg
 	return client.(*mgn.Client), nil
 }
 
+// Must wraps the _mgn.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mgn.Options)) *mgn.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mgn client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mgn client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mgn.Options)) (*mgn.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_migrationhub/client.go
+++ b/clients/_migrationhub/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _migrationhub provides AWS client management functions for the migrationhub
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*migrationhub.Optio
 	return client.(*migrationhub.Client), nil
 }
 
+// Must wraps the _migrationhub.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*migrationhub.Options)) *migrationhub.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached migrationhub client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached migrationhub client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*migrationhub.Options)) (*migrationhub.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_migrationhubconfig/client.go
+++ b/clients/_migrationhubconfig/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _migrationhubconfig provides AWS client management functions for the migrationhubconfig
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*migrationhubconfig
 	return client.(*migrationhubconfig.Client), nil
 }
 
+// Must wraps the _migrationhubconfig.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*migrationhubconfig.Options)) *migrationhubconfig.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached migrationhubconfig client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached migrationhubconfig client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*migrationhubconfig.Options)) (*migrationhubconfig.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_migrationhuborchestrator/client.go
+++ b/clients/_migrationhuborchestrator/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _migrationhuborchestrator provides AWS client management functions for the migrationhuborchestrator
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*migrationhuborches
 	return client.(*migrationhuborchestrator.Client), nil
 }
 
+// Must wraps the _migrationhuborchestrator.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*migrationhuborchestrator.Options)) *migrationhuborchestrator.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached migrationhuborchestrator client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached migrationhuborchestrator client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*migrationhuborchestrator.Options)) (*migrationhuborchestrator.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_migrationhubrefactorspaces/client.go
+++ b/clients/_migrationhubrefactorspaces/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _migrationhubrefactorspaces provides AWS client management functions for the migrationhubrefactorspaces
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*migrationhubrefact
 	return client.(*migrationhubrefactorspaces.Client), nil
 }
 
+// Must wraps the _migrationhubrefactorspaces.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*migrationhubrefactorspaces.Options)) *migrationhubrefactorspaces.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached migrationhubrefactorspaces client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached migrationhubrefactorspaces client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*migrationhubrefactorspaces.Options)) (*migrationhubrefactorspaces.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_migrationhubstrategy/client.go
+++ b/clients/_migrationhubstrategy/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _migrationhubstrategy provides AWS client management functions for the migrationhubstrategy
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*migrationhubstrate
 	return client.(*migrationhubstrategy.Client), nil
 }
 
+// Must wraps the _migrationhubstrategy.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*migrationhubstrategy.Options)) *migrationhubstrategy.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached migrationhubstrategy client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached migrationhubstrategy client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*migrationhubstrategy.Options)) (*migrationhubstrategy.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mobile/client.go
+++ b/clients/_mobile/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mobile provides AWS client management functions for the mobile
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mobile.Options)) (
 	return client.(*mobile.Client), nil
 }
 
+// Must wraps the _mobile.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mobile.Options)) *mobile.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mobile client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mobile client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mobile.Options)) (*mobile.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mq/client.go
+++ b/clients/_mq/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mq provides AWS client management functions for the mq
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mq.Options)) (*mq.
 	return client.(*mq.Client), nil
 }
 
+// Must wraps the _mq.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mq.Options)) *mq.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mq client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mq client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mq.Options)) (*mq.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mturk/client.go
+++ b/clients/_mturk/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mturk provides AWS client management functions for the mturk
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mturk.Options)) (*
 	return client.(*mturk.Client), nil
 }
 
+// Must wraps the _mturk.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mturk.Options)) *mturk.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mturk client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mturk client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mturk.Options)) (*mturk.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_mwaa/client.go
+++ b/clients/_mwaa/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _mwaa provides AWS client management functions for the mwaa
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*mwaa.Options)) (*m
 	return client.(*mwaa.Client), nil
 }
 
+// Must wraps the _mwaa.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*mwaa.Options)) *mwaa.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached mwaa client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached mwaa client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*mwaa.Options)) (*mwaa.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_neptune/client.go
+++ b/clients/_neptune/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _neptune provides AWS client management functions for the neptune
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*neptune.Options)) 
 	return client.(*neptune.Client), nil
 }
 
+// Must wraps the _neptune.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*neptune.Options)) *neptune.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached neptune client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached neptune client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*neptune.Options)) (*neptune.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_networkfirewall/client.go
+++ b/clients/_networkfirewall/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _networkfirewall provides AWS client management functions for the networkfirewall
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*networkfirewall.Op
 	return client.(*networkfirewall.Client), nil
 }
 
+// Must wraps the _networkfirewall.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*networkfirewall.Options)) *networkfirewall.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached networkfirewall client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached networkfirewall client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*networkfirewall.Options)) (*networkfirewall.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_networkmanager/client.go
+++ b/clients/_networkmanager/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _networkmanager provides AWS client management functions for the networkmanager
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*networkmanager.Opt
 	return client.(*networkmanager.Client), nil
 }
 
+// Must wraps the _networkmanager.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*networkmanager.Options)) *networkmanager.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached networkmanager client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached networkmanager client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*networkmanager.Options)) (*networkmanager.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_nimble/client.go
+++ b/clients/_nimble/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _nimble provides AWS client management functions for the nimble
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*nimble.Options)) (
 	return client.(*nimble.Client), nil
 }
 
+// Must wraps the _nimble.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*nimble.Options)) *nimble.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached nimble client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached nimble client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*nimble.Options)) (*nimble.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_oam/client.go
+++ b/clients/_oam/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _oam provides AWS client management functions for the oam
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*oam.Options)) (*oa
 	return client.(*oam.Client), nil
 }
 
+// Must wraps the _oam.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*oam.Options)) *oam.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached oam client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached oam client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*oam.Options)) (*oam.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_omics/client.go
+++ b/clients/_omics/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _omics provides AWS client management functions for the omics
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*omics.Options)) (*
 	return client.(*omics.Client), nil
 }
 
+// Must wraps the _omics.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*omics.Options)) *omics.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached omics client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached omics client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*omics.Options)) (*omics.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_opensearch/client.go
+++ b/clients/_opensearch/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _opensearch provides AWS client management functions for the opensearch
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*opensearch.Options
 	return client.(*opensearch.Client), nil
 }
 
+// Must wraps the _opensearch.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*opensearch.Options)) *opensearch.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached opensearch client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached opensearch client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*opensearch.Options)) (*opensearch.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_opensearchserverless/client.go
+++ b/clients/_opensearchserverless/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _opensearchserverless provides AWS client management functions for the opensearchserverless
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*opensearchserverle
 	return client.(*opensearchserverless.Client), nil
 }
 
+// Must wraps the _opensearchserverless.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*opensearchserverless.Options)) *opensearchserverless.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached opensearchserverless client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached opensearchserverless client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*opensearchserverless.Options)) (*opensearchserverless.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_opsworks/client.go
+++ b/clients/_opsworks/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _opsworks provides AWS client management functions for the opsworks
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*opsworks.Options))
 	return client.(*opsworks.Client), nil
 }
 
+// Must wraps the _opsworks.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*opsworks.Options)) *opsworks.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached opsworks client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached opsworks client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*opsworks.Options)) (*opsworks.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_opsworkscm/client.go
+++ b/clients/_opsworkscm/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _opsworkscm provides AWS client management functions for the opsworkscm
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*opsworkscm.Options
 	return client.(*opsworkscm.Client), nil
 }
 
+// Must wraps the _opsworkscm.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*opsworkscm.Options)) *opsworkscm.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached opsworkscm client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached opsworkscm client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*opsworkscm.Options)) (*opsworkscm.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_organizations/client.go
+++ b/clients/_organizations/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _organizations provides AWS client management functions for the organizations
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*organizations.Opti
 	return client.(*organizations.Client), nil
 }
 
+// Must wraps the _organizations.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*organizations.Options)) *organizations.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached organizations client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached organizations client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*organizations.Options)) (*organizations.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_osis/client.go
+++ b/clients/_osis/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _osis provides AWS client management functions for the osis
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*osis.Options)) (*o
 	return client.(*osis.Client), nil
 }
 
+// Must wraps the _osis.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*osis.Options)) *osis.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached osis client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached osis client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*osis.Options)) (*osis.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_outposts/client.go
+++ b/clients/_outposts/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _outposts provides AWS client management functions for the outposts
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*outposts.Options))
 	return client.(*outposts.Client), nil
 }
 
+// Must wraps the _outposts.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*outposts.Options)) *outposts.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached outposts client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached outposts client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*outposts.Options)) (*outposts.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_panorama/client.go
+++ b/clients/_panorama/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _panorama provides AWS client management functions for the panorama
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*panorama.Options))
 	return client.(*panorama.Client), nil
 }
 
+// Must wraps the _panorama.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*panorama.Options)) *panorama.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached panorama client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached panorama client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*panorama.Options)) (*panorama.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_paymentcryptography/client.go
+++ b/clients/_paymentcryptography/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _paymentcryptography provides AWS client management functions for the paymentcryptography
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*paymentcryptograph
 	return client.(*paymentcryptography.Client), nil
 }
 
+// Must wraps the _paymentcryptography.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*paymentcryptography.Options)) *paymentcryptography.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached paymentcryptography client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached paymentcryptography client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*paymentcryptography.Options)) (*paymentcryptography.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_paymentcryptographydata/client.go
+++ b/clients/_paymentcryptographydata/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _paymentcryptographydata provides AWS client management functions for the paymentcryptographydata
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*paymentcryptograph
 	return client.(*paymentcryptographydata.Client), nil
 }
 
+// Must wraps the _paymentcryptographydata.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*paymentcryptographydata.Options)) *paymentcryptographydata.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached paymentcryptographydata client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached paymentcryptographydata client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*paymentcryptographydata.Options)) (*paymentcryptographydata.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_personalize/client.go
+++ b/clients/_personalize/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _personalize provides AWS client management functions for the personalize
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*personalize.Option
 	return client.(*personalize.Client), nil
 }
 
+// Must wraps the _personalize.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*personalize.Options)) *personalize.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached personalize client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached personalize client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*personalize.Options)) (*personalize.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_personalizeevents/client.go
+++ b/clients/_personalizeevents/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _personalizeevents provides AWS client management functions for the personalizeevents
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*personalizeevents.
 	return client.(*personalizeevents.Client), nil
 }
 
+// Must wraps the _personalizeevents.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*personalizeevents.Options)) *personalizeevents.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached personalizeevents client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached personalizeevents client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*personalizeevents.Options)) (*personalizeevents.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_personalizeruntime/client.go
+++ b/clients/_personalizeruntime/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _personalizeruntime provides AWS client management functions for the personalizeruntime
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*personalizeruntime
 	return client.(*personalizeruntime.Client), nil
 }
 
+// Must wraps the _personalizeruntime.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*personalizeruntime.Options)) *personalizeruntime.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached personalizeruntime client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached personalizeruntime client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*personalizeruntime.Options)) (*personalizeruntime.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_pi/client.go
+++ b/clients/_pi/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _pi provides AWS client management functions for the pi
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*pi.Options)) (*pi.
 	return client.(*pi.Client), nil
 }
 
+// Must wraps the _pi.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*pi.Options)) *pi.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached pi client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached pi client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*pi.Options)) (*pi.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_pinpoint/client.go
+++ b/clients/_pinpoint/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _pinpoint provides AWS client management functions for the pinpoint
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*pinpoint.Options))
 	return client.(*pinpoint.Client), nil
 }
 
+// Must wraps the _pinpoint.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*pinpoint.Options)) *pinpoint.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached pinpoint client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached pinpoint client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*pinpoint.Options)) (*pinpoint.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_pinpointemail/client.go
+++ b/clients/_pinpointemail/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _pinpointemail provides AWS client management functions for the pinpointemail
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*pinpointemail.Opti
 	return client.(*pinpointemail.Client), nil
 }
 
+// Must wraps the _pinpointemail.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*pinpointemail.Options)) *pinpointemail.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached pinpointemail client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached pinpointemail client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*pinpointemail.Options)) (*pinpointemail.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_pinpointsmsvoice/client.go
+++ b/clients/_pinpointsmsvoice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _pinpointsmsvoice provides AWS client management functions for the pinpointsmsvoice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*pinpointsmsvoice.O
 	return client.(*pinpointsmsvoice.Client), nil
 }
 
+// Must wraps the _pinpointsmsvoice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*pinpointsmsvoice.Options)) *pinpointsmsvoice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached pinpointsmsvoice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached pinpointsmsvoice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*pinpointsmsvoice.Options)) (*pinpointsmsvoice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_pinpointsmsvoicev2/client.go
+++ b/clients/_pinpointsmsvoicev2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _pinpointsmsvoicev2 provides AWS client management functions for the pinpointsmsvoicev2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*pinpointsmsvoicev2
 	return client.(*pinpointsmsvoicev2.Client), nil
 }
 
+// Must wraps the _pinpointsmsvoicev2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*pinpointsmsvoicev2.Options)) *pinpointsmsvoicev2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached pinpointsmsvoicev2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached pinpointsmsvoicev2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*pinpointsmsvoicev2.Options)) (*pinpointsmsvoicev2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_pipes/client.go
+++ b/clients/_pipes/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _pipes provides AWS client management functions for the pipes
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*pipes.Options)) (*
 	return client.(*pipes.Client), nil
 }
 
+// Must wraps the _pipes.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*pipes.Options)) *pipes.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached pipes client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached pipes client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*pipes.Options)) (*pipes.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_polly/client.go
+++ b/clients/_polly/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _polly provides AWS client management functions for the polly
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*polly.Options)) (*
 	return client.(*polly.Client), nil
 }
 
+// Must wraps the _polly.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*polly.Options)) *polly.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached polly client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached polly client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*polly.Options)) (*polly.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_pricing/client.go
+++ b/clients/_pricing/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _pricing provides AWS client management functions for the pricing
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*pricing.Options)) 
 	return client.(*pricing.Client), nil
 }
 
+// Must wraps the _pricing.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*pricing.Options)) *pricing.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached pricing client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached pricing client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*pricing.Options)) (*pricing.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_privatenetworks/client.go
+++ b/clients/_privatenetworks/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _privatenetworks provides AWS client management functions for the privatenetworks
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*privatenetworks.Op
 	return client.(*privatenetworks.Client), nil
 }
 
+// Must wraps the _privatenetworks.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*privatenetworks.Options)) *privatenetworks.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached privatenetworks client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached privatenetworks client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*privatenetworks.Options)) (*privatenetworks.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_proton/client.go
+++ b/clients/_proton/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _proton provides AWS client management functions for the proton
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*proton.Options)) (
 	return client.(*proton.Client), nil
 }
 
+// Must wraps the _proton.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*proton.Options)) *proton.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached proton client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached proton client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*proton.Options)) (*proton.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_qldb/client.go
+++ b/clients/_qldb/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _qldb provides AWS client management functions for the qldb
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*qldb.Options)) (*q
 	return client.(*qldb.Client), nil
 }
 
+// Must wraps the _qldb.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*qldb.Options)) *qldb.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached qldb client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached qldb client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*qldb.Options)) (*qldb.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_qldbsession/client.go
+++ b/clients/_qldbsession/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _qldbsession provides AWS client management functions for the qldbsession
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*qldbsession.Option
 	return client.(*qldbsession.Client), nil
 }
 
+// Must wraps the _qldbsession.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*qldbsession.Options)) *qldbsession.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached qldbsession client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached qldbsession client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*qldbsession.Options)) (*qldbsession.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_quicksight/client.go
+++ b/clients/_quicksight/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _quicksight provides AWS client management functions for the quicksight
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*quicksight.Options
 	return client.(*quicksight.Client), nil
 }
 
+// Must wraps the _quicksight.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*quicksight.Options)) *quicksight.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached quicksight client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached quicksight client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*quicksight.Options)) (*quicksight.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ram/client.go
+++ b/clients/_ram/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ram provides AWS client management functions for the ram
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ram.Options)) (*ra
 	return client.(*ram.Client), nil
 }
 
+// Must wraps the _ram.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ram.Options)) *ram.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ram client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ram client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ram.Options)) (*ram.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_rbin/client.go
+++ b/clients/_rbin/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _rbin provides AWS client management functions for the rbin
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*rbin.Options)) (*r
 	return client.(*rbin.Client), nil
 }
 
+// Must wraps the _rbin.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*rbin.Options)) *rbin.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached rbin client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached rbin client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*rbin.Options)) (*rbin.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_rds/client.go
+++ b/clients/_rds/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _rds provides AWS client management functions for the rds
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*rds.Options)) (*rd
 	return client.(*rds.Client), nil
 }
 
+// Must wraps the _rds.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*rds.Options)) *rds.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached rds client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached rds client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*rds.Options)) (*rds.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_rdsdata/client.go
+++ b/clients/_rdsdata/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _rdsdata provides AWS client management functions for the rdsdata
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*rdsdata.Options)) 
 	return client.(*rdsdata.Client), nil
 }
 
+// Must wraps the _rdsdata.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*rdsdata.Options)) *rdsdata.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached rdsdata client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached rdsdata client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*rdsdata.Options)) (*rdsdata.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_redshift/client.go
+++ b/clients/_redshift/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _redshift provides AWS client management functions for the redshift
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*redshift.Options))
 	return client.(*redshift.Client), nil
 }
 
+// Must wraps the _redshift.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*redshift.Options)) *redshift.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached redshift client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached redshift client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*redshift.Options)) (*redshift.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_redshiftdata/client.go
+++ b/clients/_redshiftdata/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _redshiftdata provides AWS client management functions for the redshiftdata
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*redshiftdata.Optio
 	return client.(*redshiftdata.Client), nil
 }
 
+// Must wraps the _redshiftdata.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*redshiftdata.Options)) *redshiftdata.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached redshiftdata client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached redshiftdata client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*redshiftdata.Options)) (*redshiftdata.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_redshiftserverless/client.go
+++ b/clients/_redshiftserverless/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _redshiftserverless provides AWS client management functions for the redshiftserverless
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*redshiftserverless
 	return client.(*redshiftserverless.Client), nil
 }
 
+// Must wraps the _redshiftserverless.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*redshiftserverless.Options)) *redshiftserverless.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached redshiftserverless client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached redshiftserverless client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*redshiftserverless.Options)) (*redshiftserverless.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_rekognition/client.go
+++ b/clients/_rekognition/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _rekognition provides AWS client management functions for the rekognition
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*rekognition.Option
 	return client.(*rekognition.Client), nil
 }
 
+// Must wraps the _rekognition.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*rekognition.Options)) *rekognition.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached rekognition client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached rekognition client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*rekognition.Options)) (*rekognition.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_resiliencehub/client.go
+++ b/clients/_resiliencehub/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _resiliencehub provides AWS client management functions for the resiliencehub
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*resiliencehub.Opti
 	return client.(*resiliencehub.Client), nil
 }
 
+// Must wraps the _resiliencehub.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*resiliencehub.Options)) *resiliencehub.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached resiliencehub client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached resiliencehub client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*resiliencehub.Options)) (*resiliencehub.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_resourceexplorer2/client.go
+++ b/clients/_resourceexplorer2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _resourceexplorer2 provides AWS client management functions for the resourceexplorer2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*resourceexplorer2.
 	return client.(*resourceexplorer2.Client), nil
 }
 
+// Must wraps the _resourceexplorer2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*resourceexplorer2.Options)) *resourceexplorer2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached resourceexplorer2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached resourceexplorer2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*resourceexplorer2.Options)) (*resourceexplorer2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_resourcegroups/client.go
+++ b/clients/_resourcegroups/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _resourcegroups provides AWS client management functions for the resourcegroups
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*resourcegroups.Opt
 	return client.(*resourcegroups.Client), nil
 }
 
+// Must wraps the _resourcegroups.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*resourcegroups.Options)) *resourcegroups.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached resourcegroups client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached resourcegroups client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*resourcegroups.Options)) (*resourcegroups.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_resourcegroupstaggingapi/client.go
+++ b/clients/_resourcegroupstaggingapi/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _resourcegroupstaggingapi provides AWS client management functions for the resourcegroupstaggingapi
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*resourcegroupstagg
 	return client.(*resourcegroupstaggingapi.Client), nil
 }
 
+// Must wraps the _resourcegroupstaggingapi.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*resourcegroupstaggingapi.Options)) *resourcegroupstaggingapi.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached resourcegroupstaggingapi client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached resourcegroupstaggingapi client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_robomaker/client.go
+++ b/clients/_robomaker/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _robomaker provides AWS client management functions for the robomaker
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*robomaker.Options)
 	return client.(*robomaker.Client), nil
 }
 
+// Must wraps the _robomaker.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*robomaker.Options)) *robomaker.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached robomaker client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached robomaker client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*robomaker.Options)) (*robomaker.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_rolesanywhere/client.go
+++ b/clients/_rolesanywhere/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _rolesanywhere provides AWS client management functions for the rolesanywhere
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*rolesanywhere.Opti
 	return client.(*rolesanywhere.Client), nil
 }
 
+// Must wraps the _rolesanywhere.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*rolesanywhere.Options)) *rolesanywhere.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached rolesanywhere client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached rolesanywhere client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_route53/client.go
+++ b/clients/_route53/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _route53 provides AWS client management functions for the route53
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*route53.Options)) 
 	return client.(*route53.Client), nil
 }
 
+// Must wraps the _route53.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*route53.Options)) *route53.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached route53 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached route53 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*route53.Options)) (*route53.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_route53domains/client.go
+++ b/clients/_route53domains/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _route53domains provides AWS client management functions for the route53domains
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*route53domains.Opt
 	return client.(*route53domains.Client), nil
 }
 
+// Must wraps the _route53domains.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*route53domains.Options)) *route53domains.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached route53domains client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached route53domains client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*route53domains.Options)) (*route53domains.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_route53recoverycluster/client.go
+++ b/clients/_route53recoverycluster/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _route53recoverycluster provides AWS client management functions for the route53recoverycluster
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*route53recoveryclu
 	return client.(*route53recoverycluster.Client), nil
 }
 
+// Must wraps the _route53recoverycluster.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*route53recoverycluster.Options)) *route53recoverycluster.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached route53recoverycluster client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached route53recoverycluster client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*route53recoverycluster.Options)) (*route53recoverycluster.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_route53recoverycontrolconfig/client.go
+++ b/clients/_route53recoverycontrolconfig/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _route53recoverycontrolconfig provides AWS client management functions for the route53recoverycontrolconfig
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*route53recoverycon
 	return client.(*route53recoverycontrolconfig.Client), nil
 }
 
+// Must wraps the _route53recoverycontrolconfig.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*route53recoverycontrolconfig.Options)) *route53recoverycontrolconfig.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached route53recoverycontrolconfig client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached route53recoverycontrolconfig client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*route53recoverycontrolconfig.Options)) (*route53recoverycontrolconfig.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_route53recoveryreadiness/client.go
+++ b/clients/_route53recoveryreadiness/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _route53recoveryreadiness provides AWS client management functions for the route53recoveryreadiness
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*route53recoveryrea
 	return client.(*route53recoveryreadiness.Client), nil
 }
 
+// Must wraps the _route53recoveryreadiness.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*route53recoveryreadiness.Options)) *route53recoveryreadiness.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached route53recoveryreadiness client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached route53recoveryreadiness client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*route53recoveryreadiness.Options)) (*route53recoveryreadiness.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_route53resolver/client.go
+++ b/clients/_route53resolver/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _route53resolver provides AWS client management functions for the route53resolver
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*route53resolver.Op
 	return client.(*route53resolver.Client), nil
 }
 
+// Must wraps the _route53resolver.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*route53resolver.Options)) *route53resolver.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached route53resolver client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached route53resolver client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*route53resolver.Options)) (*route53resolver.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_rum/client.go
+++ b/clients/_rum/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _rum provides AWS client management functions for the rum
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*rum.Options)) (*ru
 	return client.(*rum.Client), nil
 }
 
+// Must wraps the _rum.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*rum.Options)) *rum.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached rum client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached rum client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*rum.Options)) (*rum.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_s3/client.go
+++ b/clients/_s3/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _s3 provides AWS client management functions for the s3
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*s3.Options)) (*s3.
 	return client.(*s3.Client), nil
 }
 
+// Must wraps the _s3.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*s3.Options)) *s3.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached s3 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached s3 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*s3.Options)) (*s3.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_s3control/client.go
+++ b/clients/_s3control/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _s3control provides AWS client management functions for the s3control
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*s3control.Options)
 	return client.(*s3control.Client), nil
 }
 
+// Must wraps the _s3control.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*s3control.Options)) *s3control.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached s3control client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached s3control client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*s3control.Options)) (*s3control.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_s3outposts/client.go
+++ b/clients/_s3outposts/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _s3outposts provides AWS client management functions for the s3outposts
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*s3outposts.Options
 	return client.(*s3outposts.Client), nil
 }
 
+// Must wraps the _s3outposts.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*s3outposts.Options)) *s3outposts.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached s3outposts client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached s3outposts client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*s3outposts.Options)) (*s3outposts.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sagemaker/client.go
+++ b/clients/_sagemaker/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sagemaker provides AWS client management functions for the sagemaker
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sagemaker.Options)
 	return client.(*sagemaker.Client), nil
 }
 
+// Must wraps the _sagemaker.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sagemaker.Options)) *sagemaker.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sagemaker client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sagemaker client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sagemaker.Options)) (*sagemaker.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sagemakera2iruntime/client.go
+++ b/clients/_sagemakera2iruntime/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sagemakera2iruntime provides AWS client management functions for the sagemakera2iruntime
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sagemakera2iruntim
 	return client.(*sagemakera2iruntime.Client), nil
 }
 
+// Must wraps the _sagemakera2iruntime.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sagemakera2iruntime.Options)) *sagemakera2iruntime.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sagemakera2iruntime client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sagemakera2iruntime client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sagemakera2iruntime.Options)) (*sagemakera2iruntime.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sagemakeredge/client.go
+++ b/clients/_sagemakeredge/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sagemakeredge provides AWS client management functions for the sagemakeredge
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sagemakeredge.Opti
 	return client.(*sagemakeredge.Client), nil
 }
 
+// Must wraps the _sagemakeredge.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sagemakeredge.Options)) *sagemakeredge.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sagemakeredge client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sagemakeredge client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sagemakeredge.Options)) (*sagemakeredge.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sagemakerfeaturestoreruntime/client.go
+++ b/clients/_sagemakerfeaturestoreruntime/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sagemakerfeaturestoreruntime provides AWS client management functions for the sagemakerfeaturestoreruntime
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sagemakerfeaturest
 	return client.(*sagemakerfeaturestoreruntime.Client), nil
 }
 
+// Must wraps the _sagemakerfeaturestoreruntime.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sagemakerfeaturestoreruntime.Options)) *sagemakerfeaturestoreruntime.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sagemakerfeaturestoreruntime client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sagemakerfeaturestoreruntime client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sagemakerfeaturestoreruntime.Options)) (*sagemakerfeaturestoreruntime.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sagemakergeospatial/client.go
+++ b/clients/_sagemakergeospatial/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sagemakergeospatial provides AWS client management functions for the sagemakergeospatial
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sagemakergeospatia
 	return client.(*sagemakergeospatial.Client), nil
 }
 
+// Must wraps the _sagemakergeospatial.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sagemakergeospatial.Options)) *sagemakergeospatial.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sagemakergeospatial client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sagemakergeospatial client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sagemakergeospatial.Options)) (*sagemakergeospatial.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sagemakermetrics/client.go
+++ b/clients/_sagemakermetrics/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sagemakermetrics provides AWS client management functions for the sagemakermetrics
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sagemakermetrics.O
 	return client.(*sagemakermetrics.Client), nil
 }
 
+// Must wraps the _sagemakermetrics.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sagemakermetrics.Options)) *sagemakermetrics.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sagemakermetrics client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sagemakermetrics client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sagemakermetrics.Options)) (*sagemakermetrics.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sagemakerruntime/client.go
+++ b/clients/_sagemakerruntime/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sagemakerruntime provides AWS client management functions for the sagemakerruntime
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sagemakerruntime.O
 	return client.(*sagemakerruntime.Client), nil
 }
 
+// Must wraps the _sagemakerruntime.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sagemakerruntime.Options)) *sagemakerruntime.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sagemakerruntime client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sagemakerruntime client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sagemakerruntime.Options)) (*sagemakerruntime.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_savingsplans/client.go
+++ b/clients/_savingsplans/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _savingsplans provides AWS client management functions for the savingsplans
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*savingsplans.Optio
 	return client.(*savingsplans.Client), nil
 }
 
+// Must wraps the _savingsplans.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*savingsplans.Options)) *savingsplans.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached savingsplans client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached savingsplans client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*savingsplans.Options)) (*savingsplans.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_scheduler/client.go
+++ b/clients/_scheduler/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _scheduler provides AWS client management functions for the scheduler
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*scheduler.Options)
 	return client.(*scheduler.Client), nil
 }
 
+// Must wraps the _scheduler.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*scheduler.Options)) *scheduler.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached scheduler client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached scheduler client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*scheduler.Options)) (*scheduler.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_schemas/client.go
+++ b/clients/_schemas/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _schemas provides AWS client management functions for the schemas
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*schemas.Options)) 
 	return client.(*schemas.Client), nil
 }
 
+// Must wraps the _schemas.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*schemas.Options)) *schemas.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached schemas client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached schemas client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*schemas.Options)) (*schemas.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_secretsmanager/client.go
+++ b/clients/_secretsmanager/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _secretsmanager provides AWS client management functions for the secretsmanager
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*secretsmanager.Opt
 	return client.(*secretsmanager.Client), nil
 }
 
+// Must wraps the _secretsmanager.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*secretsmanager.Options)) *secretsmanager.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached secretsmanager client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached secretsmanager client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*secretsmanager.Options)) (*secretsmanager.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_securityhub/client.go
+++ b/clients/_securityhub/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _securityhub provides AWS client management functions for the securityhub
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*securityhub.Option
 	return client.(*securityhub.Client), nil
 }
 
+// Must wraps the _securityhub.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*securityhub.Options)) *securityhub.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached securityhub client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached securityhub client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*securityhub.Options)) (*securityhub.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_securitylake/client.go
+++ b/clients/_securitylake/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _securitylake provides AWS client management functions for the securitylake
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*securitylake.Optio
 	return client.(*securitylake.Client), nil
 }
 
+// Must wraps the _securitylake.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*securitylake.Options)) *securitylake.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached securitylake client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached securitylake client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*securitylake.Options)) (*securitylake.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_serverlessapplicationrepository/client.go
+++ b/clients/_serverlessapplicationrepository/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _serverlessapplicationrepository provides AWS client management functions for the serverlessapplicationrepository
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*serverlessapplicat
 	return client.(*serverlessapplicationrepository.Client), nil
 }
 
+// Must wraps the _serverlessapplicationrepository.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*serverlessapplicationrepository.Options)) *serverlessapplicationrepository.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached serverlessapplicationrepository client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached serverlessapplicationrepository client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*serverlessapplicationrepository.Options)) (*serverlessapplicationrepository.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_servicecatalog/client.go
+++ b/clients/_servicecatalog/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _servicecatalog provides AWS client management functions for the servicecatalog
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*servicecatalog.Opt
 	return client.(*servicecatalog.Client), nil
 }
 
+// Must wraps the _servicecatalog.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*servicecatalog.Options)) *servicecatalog.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached servicecatalog client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached servicecatalog client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*servicecatalog.Options)) (*servicecatalog.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_servicecatalogappregistry/client.go
+++ b/clients/_servicecatalogappregistry/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _servicecatalogappregistry provides AWS client management functions for the servicecatalogappregistry
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*servicecatalogappr
 	return client.(*servicecatalogappregistry.Client), nil
 }
 
+// Must wraps the _servicecatalogappregistry.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*servicecatalogappregistry.Options)) *servicecatalogappregistry.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached servicecatalogappregistry client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached servicecatalogappregistry client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*servicecatalogappregistry.Options)) (*servicecatalogappregistry.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_servicediscovery/client.go
+++ b/clients/_servicediscovery/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _servicediscovery provides AWS client management functions for the servicediscovery
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*servicediscovery.O
 	return client.(*servicediscovery.Client), nil
 }
 
+// Must wraps the _servicediscovery.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*servicediscovery.Options)) *servicediscovery.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached servicediscovery client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached servicediscovery client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*servicediscovery.Options)) (*servicediscovery.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_servicequotas/client.go
+++ b/clients/_servicequotas/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _servicequotas provides AWS client management functions for the servicequotas
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*servicequotas.Opti
 	return client.(*servicequotas.Client), nil
 }
 
+// Must wraps the _servicequotas.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*servicequotas.Options)) *servicequotas.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached servicequotas client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached servicequotas client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*servicequotas.Options)) (*servicequotas.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ses/client.go
+++ b/clients/_ses/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ses provides AWS client management functions for the ses
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ses.Options)) (*se
 	return client.(*ses.Client), nil
 }
 
+// Must wraps the _ses.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ses.Options)) *ses.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ses client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ses client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ses.Options)) (*ses.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sesv2/client.go
+++ b/clients/_sesv2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sesv2 provides AWS client management functions for the sesv2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sesv2.Options)) (*
 	return client.(*sesv2.Client), nil
 }
 
+// Must wraps the _sesv2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sesv2.Options)) *sesv2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sesv2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sesv2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sesv2.Options)) (*sesv2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sfn/client.go
+++ b/clients/_sfn/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sfn provides AWS client management functions for the sfn
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sfn.Options)) (*sf
 	return client.(*sfn.Client), nil
 }
 
+// Must wraps the _sfn.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sfn.Options)) *sfn.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sfn client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sfn client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sfn.Options)) (*sfn.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_shield/client.go
+++ b/clients/_shield/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _shield provides AWS client management functions for the shield
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*shield.Options)) (
 	return client.(*shield.Client), nil
 }
 
+// Must wraps the _shield.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*shield.Options)) *shield.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached shield client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached shield client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*shield.Options)) (*shield.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_signer/client.go
+++ b/clients/_signer/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _signer provides AWS client management functions for the signer
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*signer.Options)) (
 	return client.(*signer.Client), nil
 }
 
+// Must wraps the _signer.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*signer.Options)) *signer.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached signer client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached signer client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*signer.Options)) (*signer.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_simspaceweaver/client.go
+++ b/clients/_simspaceweaver/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _simspaceweaver provides AWS client management functions for the simspaceweaver
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*simspaceweaver.Opt
 	return client.(*simspaceweaver.Client), nil
 }
 
+// Must wraps the _simspaceweaver.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*simspaceweaver.Options)) *simspaceweaver.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached simspaceweaver client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached simspaceweaver client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*simspaceweaver.Options)) (*simspaceweaver.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sms/client.go
+++ b/clients/_sms/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sms provides AWS client management functions for the sms
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sms.Options)) (*sm
 	return client.(*sms.Client), nil
 }
 
+// Must wraps the _sms.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sms.Options)) *sms.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sms client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sms client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sms.Options)) (*sms.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_snowball/client.go
+++ b/clients/_snowball/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _snowball provides AWS client management functions for the snowball
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*snowball.Options))
 	return client.(*snowball.Client), nil
 }
 
+// Must wraps the _snowball.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*snowball.Options)) *snowball.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached snowball client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached snowball client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*snowball.Options)) (*snowball.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_snowdevicemanagement/client.go
+++ b/clients/_snowdevicemanagement/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _snowdevicemanagement provides AWS client management functions for the snowdevicemanagement
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*snowdevicemanageme
 	return client.(*snowdevicemanagement.Client), nil
 }
 
+// Must wraps the _snowdevicemanagement.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*snowdevicemanagement.Options)) *snowdevicemanagement.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached snowdevicemanagement client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached snowdevicemanagement client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*snowdevicemanagement.Options)) (*snowdevicemanagement.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sns/client.go
+++ b/clients/_sns/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sns provides AWS client management functions for the sns
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sns.Options)) (*sn
 	return client.(*sns.Client), nil
 }
 
+// Must wraps the _sns.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sns.Options)) *sns.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sns client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sns client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sns.Options)) (*sns.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sqs/client.go
+++ b/clients/_sqs/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sqs provides AWS client management functions for the sqs
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sqs.Options)) (*sq
 	return client.(*sqs.Client), nil
 }
 
+// Must wraps the _sqs.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sqs.Options)) *sqs.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sqs client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sqs client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sqs.Options)) (*sqs.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ssm/client.go
+++ b/clients/_ssm/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ssm provides AWS client management functions for the ssm
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ssm.Options)) (*ss
 	return client.(*ssm.Client), nil
 }
 
+// Must wraps the _ssm.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ssm.Options)) *ssm.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ssm client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ssm client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ssm.Options)) (*ssm.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ssmcontacts/client.go
+++ b/clients/_ssmcontacts/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ssmcontacts provides AWS client management functions for the ssmcontacts
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ssmcontacts.Option
 	return client.(*ssmcontacts.Client), nil
 }
 
+// Must wraps the _ssmcontacts.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ssmcontacts.Options)) *ssmcontacts.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ssmcontacts client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ssmcontacts client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ssmcontacts.Options)) (*ssmcontacts.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ssmincidents/client.go
+++ b/clients/_ssmincidents/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ssmincidents provides AWS client management functions for the ssmincidents
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ssmincidents.Optio
 	return client.(*ssmincidents.Client), nil
 }
 
+// Must wraps the _ssmincidents.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ssmincidents.Options)) *ssmincidents.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ssmincidents client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ssmincidents client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ssmincidents.Options)) (*ssmincidents.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ssmsap/client.go
+++ b/clients/_ssmsap/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ssmsap provides AWS client management functions for the ssmsap
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ssmsap.Options)) (
 	return client.(*ssmsap.Client), nil
 }
 
+// Must wraps the _ssmsap.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ssmsap.Options)) *ssmsap.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ssmsap client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ssmsap client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ssmsap.Options)) (*ssmsap.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sso/client.go
+++ b/clients/_sso/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sso provides AWS client management functions for the sso
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sso.Options)) (*ss
 	return client.(*sso.Client), nil
 }
 
+// Must wraps the _sso.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sso.Options)) *sso.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sso client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sso client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sso.Options)) (*sso.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ssoadmin/client.go
+++ b/clients/_ssoadmin/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ssoadmin provides AWS client management functions for the ssoadmin
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ssoadmin.Options))
 	return client.(*ssoadmin.Client), nil
 }
 
+// Must wraps the _ssoadmin.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ssoadmin.Options)) *ssoadmin.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ssoadmin client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ssoadmin client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ssoadmin.Options)) (*ssoadmin.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_ssooidc/client.go
+++ b/clients/_ssooidc/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _ssooidc provides AWS client management functions for the ssooidc
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*ssooidc.Options)) 
 	return client.(*ssooidc.Client), nil
 }
 
+// Must wraps the _ssooidc.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*ssooidc.Options)) *ssooidc.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached ssooidc client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached ssooidc client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*ssooidc.Options)) (*ssooidc.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_storagegateway/client.go
+++ b/clients/_storagegateway/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _storagegateway provides AWS client management functions for the storagegateway
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*storagegateway.Opt
 	return client.(*storagegateway.Client), nil
 }
 
+// Must wraps the _storagegateway.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*storagegateway.Options)) *storagegateway.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached storagegateway client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached storagegateway client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*storagegateway.Options)) (*storagegateway.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_sts/client.go
+++ b/clients/_sts/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _sts provides AWS client management functions for the sts
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*sts.Options)) (*st
 	return client.(*sts.Client), nil
 }
 
+// Must wraps the _sts.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*sts.Options)) *sts.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached sts client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached sts client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*sts.Options)) (*sts.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_support/client.go
+++ b/clients/_support/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _support provides AWS client management functions for the support
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*support.Options)) 
 	return client.(*support.Client), nil
 }
 
+// Must wraps the _support.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*support.Options)) *support.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached support client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached support client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*support.Options)) (*support.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_supportapp/client.go
+++ b/clients/_supportapp/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _supportapp provides AWS client management functions for the supportapp
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*supportapp.Options
 	return client.(*supportapp.Client), nil
 }
 
+// Must wraps the _supportapp.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*supportapp.Options)) *supportapp.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached supportapp client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached supportapp client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*supportapp.Options)) (*supportapp.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_swf/client.go
+++ b/clients/_swf/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _swf provides AWS client management functions for the swf
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*swf.Options)) (*sw
 	return client.(*swf.Client), nil
 }
 
+// Must wraps the _swf.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*swf.Options)) *swf.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached swf client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached swf client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*swf.Options)) (*swf.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_synthetics/client.go
+++ b/clients/_synthetics/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _synthetics provides AWS client management functions for the synthetics
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*synthetics.Options
 	return client.(*synthetics.Client), nil
 }
 
+// Must wraps the _synthetics.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*synthetics.Options)) *synthetics.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached synthetics client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached synthetics client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*synthetics.Options)) (*synthetics.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_textract/client.go
+++ b/clients/_textract/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _textract provides AWS client management functions for the textract
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*textract.Options))
 	return client.(*textract.Client), nil
 }
 
+// Must wraps the _textract.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*textract.Options)) *textract.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached textract client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached textract client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*textract.Options)) (*textract.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_timestreamquery/client.go
+++ b/clients/_timestreamquery/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _timestreamquery provides AWS client management functions for the timestreamquery
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*timestreamquery.Op
 	return client.(*timestreamquery.Client), nil
 }
 
+// Must wraps the _timestreamquery.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*timestreamquery.Options)) *timestreamquery.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached timestreamquery client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached timestreamquery client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*timestreamquery.Options)) (*timestreamquery.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_timestreamwrite/client.go
+++ b/clients/_timestreamwrite/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _timestreamwrite provides AWS client management functions for the timestreamwrite
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*timestreamwrite.Op
 	return client.(*timestreamwrite.Client), nil
 }
 
+// Must wraps the _timestreamwrite.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*timestreamwrite.Options)) *timestreamwrite.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached timestreamwrite client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached timestreamwrite client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*timestreamwrite.Options)) (*timestreamwrite.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_tnb/client.go
+++ b/clients/_tnb/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _tnb provides AWS client management functions for the tnb
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*tnb.Options)) (*tn
 	return client.(*tnb.Client), nil
 }
 
+// Must wraps the _tnb.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*tnb.Options)) *tnb.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached tnb client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached tnb client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*tnb.Options)) (*tnb.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_transcribe/client.go
+++ b/clients/_transcribe/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _transcribe provides AWS client management functions for the transcribe
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*transcribe.Options
 	return client.(*transcribe.Client), nil
 }
 
+// Must wraps the _transcribe.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*transcribe.Options)) *transcribe.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached transcribe client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached transcribe client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*transcribe.Options)) (*transcribe.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_transcribestreaming/client.go
+++ b/clients/_transcribestreaming/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _transcribestreaming provides AWS client management functions for the transcribestreaming
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*transcribestreamin
 	return client.(*transcribestreaming.Client), nil
 }
 
+// Must wraps the _transcribestreaming.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*transcribestreaming.Options)) *transcribestreaming.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached transcribestreaming client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached transcribestreaming client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*transcribestreaming.Options)) (*transcribestreaming.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_transfer/client.go
+++ b/clients/_transfer/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _transfer provides AWS client management functions for the transfer
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*transfer.Options))
 	return client.(*transfer.Client), nil
 }
 
+// Must wraps the _transfer.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*transfer.Options)) *transfer.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached transfer client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached transfer client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*transfer.Options)) (*transfer.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_translate/client.go
+++ b/clients/_translate/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _translate provides AWS client management functions for the translate
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*translate.Options)
 	return client.(*translate.Client), nil
 }
 
+// Must wraps the _translate.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*translate.Options)) *translate.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached translate client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached translate client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*translate.Options)) (*translate.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_verifiedpermissions/client.go
+++ b/clients/_verifiedpermissions/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _verifiedpermissions provides AWS client management functions for the verifiedpermissions
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*verifiedpermission
 	return client.(*verifiedpermissions.Client), nil
 }
 
+// Must wraps the _verifiedpermissions.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*verifiedpermissions.Options)) *verifiedpermissions.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached verifiedpermissions client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached verifiedpermissions client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*verifiedpermissions.Options)) (*verifiedpermissions.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_voiceid/client.go
+++ b/clients/_voiceid/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _voiceid provides AWS client management functions for the voiceid
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*voiceid.Options)) 
 	return client.(*voiceid.Client), nil
 }
 
+// Must wraps the _voiceid.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*voiceid.Options)) *voiceid.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached voiceid client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached voiceid client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*voiceid.Options)) (*voiceid.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_vpclattice/client.go
+++ b/clients/_vpclattice/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _vpclattice provides AWS client management functions for the vpclattice
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*vpclattice.Options
 	return client.(*vpclattice.Client), nil
 }
 
+// Must wraps the _vpclattice.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*vpclattice.Options)) *vpclattice.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached vpclattice client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached vpclattice client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*vpclattice.Options)) (*vpclattice.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_waf/client.go
+++ b/clients/_waf/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _waf provides AWS client management functions for the waf
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*waf.Options)) (*wa
 	return client.(*waf.Client), nil
 }
 
+// Must wraps the _waf.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*waf.Options)) *waf.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached waf client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached waf client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*waf.Options)) (*waf.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_wafregional/client.go
+++ b/clients/_wafregional/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _wafregional provides AWS client management functions for the wafregional
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*wafregional.Option
 	return client.(*wafregional.Client), nil
 }
 
+// Must wraps the _wafregional.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*wafregional.Options)) *wafregional.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached wafregional client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached wafregional client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*wafregional.Options)) (*wafregional.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_wafv2/client.go
+++ b/clients/_wafv2/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _wafv2 provides AWS client management functions for the wafv2
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*wafv2.Options)) (*
 	return client.(*wafv2.Client), nil
 }
 
+// Must wraps the _wafv2.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*wafv2.Options)) *wafv2.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached wafv2 client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached wafv2 client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*wafv2.Options)) (*wafv2.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_wellarchitected/client.go
+++ b/clients/_wellarchitected/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _wellarchitected provides AWS client management functions for the wellarchitected
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*wellarchitected.Op
 	return client.(*wellarchitected.Client), nil
 }
 
+// Must wraps the _wellarchitected.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*wellarchitected.Options)) *wellarchitected.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached wellarchitected client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached wellarchitected client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*wellarchitected.Options)) (*wellarchitected.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_wisdom/client.go
+++ b/clients/_wisdom/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _wisdom provides AWS client management functions for the wisdom
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*wisdom.Options)) (
 	return client.(*wisdom.Client), nil
 }
 
+// Must wraps the _wisdom.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*wisdom.Options)) *wisdom.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached wisdom client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached wisdom client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*wisdom.Options)) (*wisdom.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_workdocs/client.go
+++ b/clients/_workdocs/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _workdocs provides AWS client management functions for the workdocs
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*workdocs.Options))
 	return client.(*workdocs.Client), nil
 }
 
+// Must wraps the _workdocs.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*workdocs.Options)) *workdocs.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached workdocs client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached workdocs client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*workdocs.Options)) (*workdocs.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_worklink/client.go
+++ b/clients/_worklink/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _worklink provides AWS client management functions for the worklink
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*worklink.Options))
 	return client.(*worklink.Client), nil
 }
 
+// Must wraps the _worklink.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*worklink.Options)) *worklink.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached worklink client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached worklink client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*worklink.Options)) (*worklink.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_workmail/client.go
+++ b/clients/_workmail/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _workmail provides AWS client management functions for the workmail
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*workmail.Options))
 	return client.(*workmail.Client), nil
 }
 
+// Must wraps the _workmail.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*workmail.Options)) *workmail.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached workmail client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached workmail client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*workmail.Options)) (*workmail.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_workmailmessageflow/client.go
+++ b/clients/_workmailmessageflow/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _workmailmessageflow provides AWS client management functions for the workmailmessageflow
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*workmailmessageflo
 	return client.(*workmailmessageflow.Client), nil
 }
 
+// Must wraps the _workmailmessageflow.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*workmailmessageflow.Options)) *workmailmessageflow.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached workmailmessageflow client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached workmailmessageflow client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*workmailmessageflow.Options)) (*workmailmessageflow.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_workspaces/client.go
+++ b/clients/_workspaces/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _workspaces provides AWS client management functions for the workspaces
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*workspaces.Options
 	return client.(*workspaces.Client), nil
 }
 
+// Must wraps the _workspaces.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*workspaces.Options)) *workspaces.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached workspaces client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached workspaces client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*workspaces.Options)) (*workspaces.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_workspacesweb/client.go
+++ b/clients/_workspacesweb/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _workspacesweb provides AWS client management functions for the workspacesweb
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*workspacesweb.Opti
 	return client.(*workspacesweb.Client), nil
 }
 
+// Must wraps the _workspacesweb.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*workspacesweb.Options)) *workspacesweb.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached workspacesweb client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached workspacesweb client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*workspacesweb.Options)) (*workspacesweb.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/clients/_xray/client.go
+++ b/clients/_xray/client.go
@@ -1,6 +1,6 @@
 // AUTO-GENERATED CODE - DO NOT EDIT
 // See instructions under /codegen/README.md
-// GENERATED ON 2023-06-16 18:24:12
+// GENERATED ON 2023-07-31 09:25:17
 
 // Package _xray provides AWS client management functions for the xray
 // AWS service.
@@ -37,6 +37,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*xray.Options)) (*x
 	return client.(*xray.Client), nil
 }
 
+// Must wraps the _xray.Client( ) function & panics if a non-nil error is returned.
+func Must(provider providers.CredsProvider, optFns ...func(*xray.Options)) *xray.Client {
+
+	client, err := Client(provider, optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached xray client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -48,4 +58,14 @@ func Delete(provider providers.CredsProvider) error {
 		cmap.Delete(provider.Key())
 	}
 	return nil
+}
+
+// Refresh discards the cached xray client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*xray.Options)) (*xray.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider, optFns...)
 }

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -221,6 +221,16 @@ func Client(provider providers.CredsProvider, optFns ...func(*{{ $svc }}.Options
 	return client.(*{{ $svc }}.Client), nil
 }
 
+// Must wraps the _{{ $svc }}.Client( ) function & panics if a non-nil error is returned. 
+func Must(provider providers.CredsProvider, optFns ...func(*{{ $svc }}.Options)) *{{ $svc }}.Client {
+
+	client, err := Client(provider,optFns...)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
 // Delete removes the cached {{ $svc }} client for the supplied provider; This foreces the subsequent
 // calls to Client() for the same provider to recreate & return a new instnce.
 func Delete(provider providers.CredsProvider) error {
@@ -233,6 +243,18 @@ func Delete(provider providers.CredsProvider) error {
 	}
 	return nil
 }
+
+
+// Refresh discards the cached {{ $svc }} client if it exists, builds & returns a new singleton instance
+func Refresh(provider providers.CredsProvider, optFns ...func(*{{ $svc }}.Options)) (*{{ $svc }}.Client, error) {
+
+	err := Delete(provider)
+	if err != nil {
+		return nil, err
+	}
+	return Client(provider,optFns...)
+}
+
 
 {{ end }}
 `))


### PR DESCRIPTION
The `Must()` function is a wrapper for the `Client()` function & panics if a non-nil error is returned. It 
allows convenience for initializing or passing AWS clients in the client code.

The `Refresh()` function discards the singleton client if it exists & recreates it.
