### PR TITLE
feat(devops-8450) retracting all tags for this library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,15 @@ module github.com/TouchBistro/aws-ccp-go
 
 go 1.21
 
+// This module is being decommissioned. Please use github.com/TouchBistro/awesome instead.
+retract (
+	v0.0.5
+	v0.0.4
+	v0.0.3
+	v0.0.2
+	v0.0.1
+)
+
 require (
 	github.com/aws/aws-sdk-go-v2 v1.27.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.16


### PR DESCRIPTION
## Summary
- Adds `retract` directives for all published tags (`v0.0.1`–`v0.0.5`) in `go.mod`
- This library is being decommissioned; consumers should migrate to `github.com/TouchBistro/awesome`

## Test plan
- [ ] Verify `go list -m -json github.com/TouchBistro/aws-ccp-go@v0.0.5` shows retraction warning after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)